### PR TITLE
fix: update Wokwi simulation to working configuration

### DIFF
--- a/diagram.json
+++ b/diagram.json
@@ -1,0 +1,45 @@
+{
+  "version": 1,
+  "author": "Jules and Lawrence",
+  "editor": "wokwi",
+  "parts": [
+    {
+      "type": "board-esp32-s3-devkitc-1",
+      "id": "esp",
+      "top": -48.18,
+      "left": -33.83,
+      "attrs": {}
+    },
+    {
+      "type": "wokwi-led-ring",
+      "id": "leds",
+      "top": 39.04,
+      "left": 116.39,
+      "attrs": { "leds": "8" }
+    },
+    {
+      "type": "wokwi-pushbutton",
+      "id": "btn",
+      "top": -3.4,
+      "left": 268.8,
+      "attrs": { "color": "black", "bounce": "1" }
+    },
+    { "type": "wokwi-microsd-card", "id": "sd", "top": -9.37, "left": -86.33, "attrs": {} }
+  ],
+  "connections": [
+    [ "esp:GND.1", "sd:GND", "black", [ "v0" ] ],
+    [ "esp:3V3.1", "sd:VCC", "red", [ "v0" ] ],
+    [ "esp:GND.2", "leds:GND", "black", [ "v0" ] ],
+    [ "esp:5V", "leds:VCC", "red", [ "v0" ] ],
+    [ "esp:GND.3", "btn:2.r", "black", [ "v0" ] ],
+    [ "esp:20", "btn:1.r", "green", [ "v0" ] ],
+    [ "esp:4", "leds:DIN", "white", [ "v0" ] ],
+    [ "esp:5", "sd:CS", "yellow", [ "v0" ] ],
+    [ "esp:18", "sd:SCK", "blue", [ "v0" ] ],
+    [ "esp:19", "sd:DO", "green", [ "v0" ] ],
+    [ "esp:23", "sd:DI", "orange", [ "v0" ] ],
+    [ "esp:TX", "$serialMonitor:RX", "", [] ],
+    [ "esp:RX", "$serialMonitor:TX", "", [] ]
+  ],
+  "dependencies": {}
+}

--- a/main/main.c
+++ b/main/main.c
@@ -99,7 +99,7 @@
 #define LED_STRIP_RMT_RES_HZ        (10 * 1000 * 1000) // 10MHz resolution
 
 // Eject Button
-#define EJECT_BUTTON_GPIO           33
+#define EJECT_BUTTON_GPIO           20
 
 
 // --- GLOBALS ---

--- a/wokwi.toml
+++ b/wokwi.toml
@@ -1,0 +1,8 @@
+[wokwi]
+version = 1
+elf = "build/library-lamp.elf"
+firmware = "build/library-lamp.bin"
+
+[[spiffs]]
+image = "main/web_assets"
+partition = "storage"


### PR DESCRIPTION
This commit updates the Wokwi simulation environment based on user feedback to ensure it is fully functional.

The following changes were made:

- `diagram.json`: The diagram has been updated to use the `board-esp32-s3-devkitc-1` board, a `wokwi-led-ring`, and a `wokwi-microsd-card`. The pushbutton has been moved to GPIO20 and the SD card is now powered by 3.3V.

- `main/main.c`: The `EJECT_BUTTON_GPIO` macro has been changed from 33 to 20 to match the updated `diagram.json`.

These changes reflect a tested, working configuration provided by the user, ensuring the simulation is accurate and usable for development and E2E testing.