### PR TITLE
fix: Resolve build errors for missing headers and format specifiers

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -32,6 +32,8 @@ idf_component_register(SRCS "${COMPONENT_SRCS}"
 
                                 # USB Host components
                                 usb
+                                esp_driver_usb
+                                esp_driver_gpio
 
                                 # Peripherals
                                 esp_driver_rmt

--- a/main/dns_server.c
+++ b/main/dns_server.c
@@ -12,6 +12,7 @@
 #include "esp_log.h"
 #include "esp_system.h"
 #include "esp_netif.h"
+#include <inttypes.h>
 
 #include "lwip/err.h"
 #include "lwip/sockets.h"
@@ -149,7 +150,7 @@ static int parse_dns_request(char *req, size_t req_len, char *dns_reply, size_t 
 
             esp_netif_ip_info_t ip_info;
             esp_netif_get_ip_info(esp_netif_get_handle_from_ifkey("WIFI_AP_DEF"), &ip_info);
-            ESP_LOGD(TAG, "Answer with PTR offset: 0x%X and IP 0x%X", ntohs(answer->ptr_offset), ip_info.ip.addr);
+            ESP_LOGD(TAG, "Answer with PTR offset: 0x%X and IP 0x%" PRIx32, ntohs(answer->ptr_offset), ip_info.ip.addr);
 
             answer->addr_len = htons(sizeof(ip_info.ip.addr));
             answer->ip_addr = ip_info.ip.addr;


### PR DESCRIPTION
This commit resolves two critical build errors that were preventing the project from compiling.

First, a fatal error `esp_usb.h: No such file or directory` was occurring because the necessary USB driver component was not included in the build. This is resolved by adding `esp_driver_usb` and its dependency `esp_driver_gpio` to the `REQUIRES` list in `main/CMakeLists.txt`.

Second, compiler warnings were being treated as errors due to incorrect format specifiers in `main/dns_server.c`. The `%X` specifier was being used for a `uint32_t` type. This is fixed by including `<inttypes.h>` and using the correct `PRIx32` macro for printing 32-bit hexadecimal values in a portable way.