### PR TITLE
Add Wio-SX1262 LoRa module SPI and control pin definitions to lorawan.h

### DIFF
--- a/main/lorawan.h
+++ b/main/lorawan.h
@@ -1,6 +1,21 @@
 #ifndef LORAWAN_H
 #define LORAWAN_H
 
+// Wio-SX1262 LoRa module pins (XIAO ESP32S3)
+#define LORA_USE_SX1262
+
+// SPI Interface
+#define LORA_MISO_PIN 8
+#define LORA_SCK_PIN  7
+#define LORA_MOSI_PIN 9
+#define LORA_CS_PIN   5
+
+// Control Pins
+#define LORA_RST_PIN  3
+#define LORA_BUSY_PIN 4
+#define LORA_DIO1_PIN 2
+#define LORA_DIO2_PIN 6 // DIO2 typically controls the RF switch
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Defined SPI pins (MISO, MOSI, SCK, CS) and module-specific control pins (RST, BUSY, DIO1, DIO2) for the Wio-SX1262 LoRa module on the XIAO ESP32S3 in `main/lorawan.h`. This sets up the correct GPIO configuration required for integrating the actual LoRaWAN driver component later.

---
*PR created automatically by Jules for task [1930181923882588718](https://jules.google.com/task/1930181923882588718) started by @LokiMetaSmith*