### PR TITLE
Add RadioLib to IDF component manager

### DIFF
--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -4,3 +4,4 @@ dependencies:
   espressif/usb_host_hid: "^1.2.0"
   espressif/usb_host_msc: "^1.2.0"
   espressif/led_strip: "^2.0.0"
+  jgromes/RadioLib: "*"


### PR DESCRIPTION
Added `jgromes/RadioLib` to `main/idf_component.yml` to resolve "unknown name" CMake error. The uninitialized `components/RadioLib` directory was deleted to prevent conflicts with the component manager.