### PR TITLE
Fix CMake linking for RadioLib component

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -46,7 +46,7 @@ idf_component_register(SRCS "${COMPONENT_SRCS}"
                          bt
 
                          # External Components
-                         RadioLib
+                         radiolib
 )
 # Generate the SPIFFS image from the web_assets directory
 set(SPIFFS_IMAGE_DIR "${CMAKE_CURRENT_LIST_DIR}/web_assets")


### PR DESCRIPTION
Updated `main/CMakeLists.txt` to require `radiolib` (lowercase) instead of `RadioLib`. The IDF component manager registers the dependency package name in lowercase, which was causing an 'unknown name' resolution failure during the CMake configuration.