### PR TITLE
build: update led_strip component for ESP-IDF v6 compatibility

### DIFF
--- a/dependencies.lock
+++ b/dependencies.lock
@@ -1,10 +1,10 @@
 dependencies:
   espressif/led_strip:
-    component_hash: 28c6509a727ef74925b372ed404772aeedf11cce10b78c3f69b3c66799095e2d
+    component_hash: 28621486f77229aaf81c71f5e15d6fbf36c2949cf11094e07090593e659e7639
     source:
       service_url: https://api.components.espressif.com/
       type: service
-    version: 2.5.5
+    version: 3.0.3
   espressif/usb_host_hid:
     component_hash: a6c5366f9b6d80b0d5f56d085d62941464512e0968b96c5877e76a80fcc23f13
     source:
@@ -28,6 +28,6 @@ dependencies:
       service_url: https://api.components.espressif.com/
       type: service
     version: 7.7.1
-manifest_hash: c3ed6fbab079b60da8e1b5958df433ba17c8a11d2196300c7747258acdbd2034
+manifest_hash: aaedfae3df82c2c47854f06b9ae18bde26198db80478f1e3593c2068df264f49
 target: esp32s3
 version: 1.0.0

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -3,5 +3,5 @@ dependencies:
   idf: ">=4.4"
   espressif/usb_host_hid: "^1.2.0"
   espressif/usb_host_msc: "^1.2.0"
-  espressif/led_strip: "^2.0.0"
+  espressif/led_strip: "^3.0.0"
   jgromes/radiolib: "*"


### PR DESCRIPTION
Resolves compilation errors with ESP-IDF v6.0.1 by updating the `espressif/led_strip` component to `^3.0.0`. Older versions of the component relied on `MALLOC_CAP_DEFAULT` which is undeclared in newer IDF versions.

---
*PR created automatically by Jules for task [14385838720451404653](https://jules.google.com/task/14385838720451404653) started by @LokiMetaSmith*