### PR TITLE
fix: resolve cJSON header and sqlite3 warnings causing build failures

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -47,6 +47,7 @@ idf_component_register(SRCS "${COMPONENT_SRCS}"
 
                          # External Components
                          radiolib
+                         json
 )
 # Generate the SPIFFS image from the web_assets directory
 set(SPIFFS_IMAGE_DIR "${CMAKE_CURRENT_LIST_DIR}/web_assets")

--- a/sqlite3/CMakeLists.txt
+++ b/sqlite3/CMakeLists.txt
@@ -10,3 +10,12 @@ idf_component_register(
     INCLUDE_DIRS
         "."
 )
+
+target_compile_options(${COMPONENT_LIB} PRIVATE
+    -Wno-error
+    -Wno-unused-variable
+    -Wno-unused-but-set-variable
+    -Wno-missing-field-initializers
+    -Wno-implicit-fallthrough
+    -Wno-type-limits
+)


### PR DESCRIPTION
Resolved compilation errors observed during firmware building.
1. Fixed `fatal error: cJSON.h: No such file or directory` by ensuring the ESP-IDF `json` component is required in `main`.
2. Fixed multiple build failures in the third-party `sqlite3` component caused by standard `-Werror` treatment. Specifically disabled errors for unused variables, missing field initializers, type limits, and implicit fallthroughs for just the `sqlite3` component.

---
*PR created automatically by Jules for task [11001058536822850609](https://jules.google.com/task/11001058536822850609) started by @LokiMetaSmith*