### PR TITLE
build: add sqlite3 to main component dependencies

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -48,6 +48,7 @@ idf_component_register(SRCS "${COMPONENT_SRCS}"
                          # External Components
                          radiolib
                          cjson
+                         sqlite3
 )
 # Generate the SPIFFS image from the web_assets directory
 set(SPIFFS_IMAGE_DIR "${CMAKE_CURRENT_LIST_DIR}/web_assets")


### PR DESCRIPTION
Fixes the `sqlite3.h: No such file or directory` compile error by explicitly requiring the local `sqlite3` component in `main/CMakeLists.txt`.

---
*PR created automatically by Jules for task [16144676173730417728](https://jules.google.com/task/16144676173730417728) started by @LokiMetaSmith*