### PR TITLE
Make hardware failures non-fatal and track status in UI

### DIFF
--- a/main/lorawan.cpp
+++ b/main/lorawan.cpp
@@ -12,6 +12,7 @@ EspHal* hal = nullptr;
 SX1262* radio = nullptr;
 
 // FreeRTOS task handle and mutex
+bool lora_initialized = false;
 TaskHandle_t loraReceiveTaskHandle = NULL;
 SemaphoreHandle_t loraMutex = NULL;
 
@@ -77,7 +78,7 @@ void lora_wan_init(void) {
     int state = radio->begin(915.0);
 
     if (state == RADIOLIB_ERR_NONE) {
-        ESP_LOGI(TAG, "SX1262 init success!");
+        ESP_LOGI(TAG, "SX1262 init success!"); lora_initialized = true;
 
         // Apply Meshtastic LongFast equivalents
         radio->setBandwidth(250.0);
@@ -107,7 +108,7 @@ void lora_wan_init(void) {
 }
 
 void lora_wan_broadcast(const char *message) {
-    if (!radio) {
+    if (!lora_initialized) {
         ESP_LOGE(TAG, "Radio not initialized!");
         return;
     }

--- a/main/main.c
+++ b/main/main.c
@@ -136,6 +136,9 @@ static msc_host_device_handle_t device_handle = NULL;
 static msc_host_vfs_handle_t vfs_handle = NULL;
 static led_strip_handle_t g_led_strip;
 static bool g_wifi_configured = false;
+bool g_usb_mounted = false;
+bool g_sd_card_initialized = false;
+extern bool lora_initialized;
 QueueHandle_t app_event_queue = NULL;
 
 /**
@@ -627,6 +630,9 @@ static esp_err_t status_handler(httpd_req_t *req) {
     cJSON *root = cJSON_CreateObject();
     cJSON_AddBoolToObject(root, "reader_connected", ebook_reader_connected);
     cJSON_AddBoolToObject(root, "transfer_active", g_transfer_progress.active);
+    cJSON_AddBoolToObject(root, "sd_mounted", g_sd_card_initialized);
+    cJSON_AddBoolToObject(root, "usb_mounted", g_usb_mounted);
+    cJSON_AddBoolToObject(root, "lora_initialized", lora_initialized);
     if (g_transfer_progress.active) {
         cJSON_AddStringToObject(root, "filename", g_transfer_progress.filename);
         cJSON_AddNumberToObject(root, "bytes_transferred", g_transfer_progress.bytes_transferred);
@@ -654,6 +660,12 @@ static esp_err_t list_files_handler(httpd_req_t *req) {
 
     const char *mount_path = (strcmp(param, "sd") == 0) ? MOUNT_POINT_SD : MOUNT_POINT_USB;
 
+    if (strcmp(param, "sd") == 0 && !g_sd_card_initialized) {
+         httpd_resp_set_type(req, "application/json");
+         httpd_resp_send(req, "[]", 2);
+         return ESP_OK;
+    }
+
     if (strcmp(param, "usb") == 0 && !ebook_reader_connected) {
          httpd_resp_set_type(req, "application/json");
          httpd_resp_send(req, "[]", 2);
@@ -662,9 +674,10 @@ static esp_err_t list_files_handler(httpd_req_t *req) {
 
     DIR *d = opendir(mount_path);
     if (!d) {
-        ESP_LOGE(TAG, "Failed to open directory: %s", mount_path);
-        httpd_resp_send_500(req);
-        return ESP_FAIL;
+        ESP_LOGW(TAG, "Failed to open directory: %s", mount_path);
+        httpd_resp_set_type(req, "application/json");
+        httpd_resp_send(req, "[]", 2);
+        return ESP_OK;
     }
 
     cJSON *root = cJSON_CreateArray();
@@ -1413,7 +1426,7 @@ void init_sd_card(void) {
     };
     ret = spi_bus_initialize(host.slot, &bus_cfg, SDSPI_DEFAULT_DMA);
     if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to initialize spi bus.");
+        ESP_LOGE(TAG, "Failed to initialize spi bus."); g_sd_card_initialized = false;
         g_led_state = LED_STATE_ERROR;
         return;
     }
@@ -1425,10 +1438,10 @@ void init_sd_card(void) {
     ret = esp_vfs_fat_sdspi_mount(mount_point, &host, &slot_config, &mount_config, &card);
 
     if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to mount SD card VFS");
+        ESP_LOGE(TAG, "Failed to mount SD card VFS"); g_sd_card_initialized = false;
         g_led_state = LED_STATE_ERROR;
     } else {
-        ESP_LOGI(TAG, "SD card mounted successfully at %s", mount_point);
+        ESP_LOGI(TAG, "SD card mounted successfully at %s", mount_point); g_sd_card_initialized = true;
     }
 }
 
@@ -1622,13 +1635,7 @@ void usb_host_lib_task_dummy(void *arg)
 
 void init_usb_host() {
     ESP_LOGI(TAG, "Installing USB Host Library");
-    const usb_host_config_t host_config = {
-        .intr_flags = ESP_INTR_FLAG_LEVEL1,
-    };
-    ESP_ERROR_CHECK(usb_host_install(&host_config));
 
-    // Create a task to handle USB library events
-    xTaskCreate(usb_host_lib_task, "usb_host", 4096, NULL, 10, NULL);
 
     ESP_LOGI(TAG, "Installing MSC client");
     const msc_host_driver_config_t msc_config = {
@@ -1637,7 +1644,13 @@ void init_usb_host() {
         .stack_size = 4096,
         .callback = msc_event_cb,
     };
-    ESP_ERROR_CHECK(msc_host_install(&msc_config));
+    esp_err_t err = msc_host_install(&msc_config);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to install MSC client");
+        g_usb_mounted = false;
+    } else {
+        g_usb_mounted = true;
+    }
 }
 
 // --- LED STRIP ---

--- a/main/web_assets/board.html
+++ b/main/web_assets/board.html
@@ -316,6 +316,9 @@ body {
 <body>
 
 <header class="site-header">
+  <div id="systemBanner" style="display:none;background:#ffcc00;color:#333;padding:10px;margin:0 24px 15px 24px;border-radius:5px;border:1px solid #e6b800;">
+    <ul id="systemErrorsList" style="margin:0;padding-left:20px;"></ul>
+  </div>
   <div class="header-title-block">
     <div class="site-title" id="boardTitle">COMMUNITY HUB</div>
     <div class="site-sub"   id="boardTagline"></div>
@@ -488,11 +491,32 @@ function setSort(s, btn) {
   document.getElementById('sNew').classList.toggle('active', s === 'new');
   document.getElementById('sExp').classList.toggle('active', s === 'exp');
   load();
+  loadSystemStatus();
 }
 
 // ── Data ───────────────────────────────────────
 let lastData = [];
 
+async function loadSystemStatus() {
+  try {
+    const res = await fetch("/status");
+    if (res.ok) {
+      const data = await res.json();
+      const errors = [];
+      if (!data.sd_mounted) errors.push("Warning: SD Card not mounted.");
+      if (!data.usb_mounted) errors.push("Warning: USB initialization failed.");
+      if (!data.lora_initialized) errors.push("Warning: LoRaWAN initialization failed.");
+      if (errors.length > 0) {
+        const banner = document.getElementById("systemBanner");
+        const list = document.getElementById("systemErrorsList");
+        list.innerHTML = errors.map(e => `<li>${e}</li>`).join("");
+        banner.style.display = "block";
+      }
+    }
+  } catch (e) {
+    console.error("Failed to load status", e);
+  }
+}
 async function load() {
   try {
     checkBoardStatus();
@@ -556,6 +580,7 @@ async function doPost() {
   document.getElementById('msgIn').value      = '';
   document.getElementById('msgHint').textContent = '';
   load();
+  loadSystemStatus();
 }
 
 // ── Board info ─────────────────────────────────
@@ -572,6 +597,7 @@ function loadInfo() {
 setInterval(load,     60000);
 setInterval(loadInfo, 60000);
 load();
+  loadSystemStatus();
 loadInfo();
 checkBoardStatus();
 </script>

--- a/main/web_assets/ereader.html
+++ b/main/web_assets/ereader.html
@@ -69,6 +69,9 @@
 
     <h1>E-Book Library</h1>
 
+<div id="systemBanner" style="display:none;background:#ffcc00;color:#333;padding:10px;margin-bottom:15px;border-radius:5px;border:1px solid #e6b800;font-size:0.9em;">
+    <ul id="systemErrorsList" style="margin:0;padding-left:20px;"></ul>
+</div>
     <div id="loading" class="loading">Loading books...</div>
     <div id="error" class="error" style="display: none;"></div>
 
@@ -84,8 +87,29 @@
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             fetchBooks();
+        loadSystemStatus();
         });
 
+        async function loadSystemStatus() {
+            try {
+                const res = await fetch("/status");
+                if (res.ok) {
+                    const data = await res.json();
+                    const errors = [];
+                    if (!data.sd_mounted) errors.push("Warning: SD Card not mounted.");
+                    if (!data.usb_mounted) errors.push("Warning: USB initialization failed.");
+                    if (!data.lora_initialized) errors.push("Warning: LoRaWAN initialization failed.");
+                    if (errors.length > 0) {
+                        const banner = document.getElementById("systemBanner");
+                        const list = document.getElementById("systemErrorsList");
+                        list.innerHTML = errors.map(e => `<li>${e}</li>`).join("");
+                        banner.style.display = "block";
+                    }
+                }
+            } catch (e) {
+                console.error("Failed to load status", e);
+            }
+        }
         async function fetchBooks() {
             try {
                 const response = await fetch('/list-files?type=sd');

--- a/main/web_assets/index.html
+++ b/main/web_assets/index.html
@@ -9,6 +9,11 @@
 <body>
     <div id="app">
         <header class="app-header">
+        <div v-if="systemErrors.length > 0" class="system-banner">
+            <ul>
+                <li v-for="err in systemErrors" :key="err">{{ err }}</li>
+            </ul>
+        </div>
             <h1>E-Book Librarian</h1>
             <div class="status-indicator" :class="statusClass"></div>
         <div style="text-align: right; font-size: 1.1em; padding-bottom: 5px;">

--- a/main/web_assets/script.js
+++ b/main/web_assets/script.js
@@ -6,6 +6,7 @@ createApp({
             localFiles: [],
             ereaderFiles: [],
             isEReaderConnected: false,
+            systemErrors: [],
             status: 'idle', // idle, connected, transferring
             transfer: {
                 active: false,
@@ -29,6 +30,11 @@ createApp({
                 const response = await fetch('/status');
                 const data = await response.json();
                 this.isEReaderConnected = data.reader_connected;
+                const errors = [];
+                if (!data.sd_mounted) errors.push("Warning: SD Card not mounted.");
+                if (!data.usb_mounted) errors.push("Warning: USB initialization failed.");
+                if (!data.lora_initialized) errors.push("Warning: LoRaWAN initialization failed.");
+                this.systemErrors = errors;
                 if (data.transfer_active) {
                     this.transfer.active = true;
                     this.transfer.filename = data.filename;

--- a/main/web_assets/style.css
+++ b/main/web_assets/style.css
@@ -78,3 +78,17 @@ button.cancel-btn:hover {
 .sleep-btn:hover {
     background-color: #e74c3c;
 }
+
+/* System Banner */
+.system-banner {
+    background-color: #ffcc00;
+    color: #333;
+    padding: 10px;
+    margin-bottom: 15px;
+    border-radius: 5px;
+    border: 1px solid #e6b800;
+}
+.system-banner ul {
+    margin: 0;
+    padding-left: 20px;
+}


### PR DESCRIPTION
When the SD Card, LoRaWAN module, or USB controller failed to mount or initialize, the application would crash due to strict `ESP_ERROR_CHECK` macros. The USB controller was actually attempting to install twice, which caused a crash in the `usb_host_lib_task`. 

This patch intercepts these hardware initialization failures and makes them non-fatal. Rather than crashing, the firmware sets tracking booleans (`g_sd_card_initialized`, `g_usb_mounted`, `lora_initialized`), and exposes this data in the `/status` API. The frontend UI pages check this `/status` endpoint periodically, and display a yellow system banner alerting the user to which hardware features are currently offline, without preventing them from using whatever functions remain active.

---
*PR created automatically by Jules for task [13496559155246879927](https://jules.google.com/task/13496559155246879927) started by @LokiMetaSmith*