### PR TITLE
feat: implement banned book library UI/UX features

### DIFF
--- a/build_output.log
+++ b/build_output.log
@@ -1,0 +1,351 @@
+Setting up ESP32 Dev Environment and PlatformIO...
+Ensuring platformio is installed in the virtual environment...
+
+[notice] A new release of pip is available: 25.0.1 -> 26.1.2
+[notice] To update, run: /app/.venv/bin/python -m pip install --upgrade pip
+Building firmware with PlatformIO...
+Processing esp32-s3-ebook-librarian (platform: espressif32@6.11.0; framework: espidf; board: esp32s3usbotg)
+--------------------------------------------------------------------------------
+Verbose mode can be enabled via `-v, --verbose` option
+CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32s3usbotg.html
+PLATFORM: Espressif 32 (6.11.0) > Espressif ESP32-S3-USB-OTG
+HARDWARE: ESP32S3 240MHz, 320KB RAM, 8MB Flash
+DEBUG: Current (esp-builtin) On-board (esp-builtin) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+PACKAGES:
+ - framework-espidf @ 3.50401.0 (5.4.1)
+ - tool-cmake @ 3.16.4
+ - tool-esp-rom-elfs @ 0.0.1+20241011
+ - tool-esptoolpy @ 1.40501.0 (4.5.1)
+ - tool-ninja @ 1.7.1
+ - tool-riscv32-esp-elf-gdb @ 12.1.0+20221002
+ - tool-xtensa-esp-elf-gdb @ 12.1.0+20221002
+ - toolchain-esp32ulp @ 1.23800.240113 (2.38.0)
+ - toolchain-riscv32-esp @ 14.2.0+20241119
+ - toolchain-xtensa-esp-elf @ 14.2.0+20241119
+Reading CMake configuration...
+LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+LDF Modes: Finder ~ chain, Compatibility ~ soft
+Found 0 compatible libraries
+Scanning dependencies...
+No dependencies
+Building in release mode
+Compiling .pio/build/esp32-s3-ebook-librarian/sqlite3/sqlite3.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/wpa_supplicant/esp_supplicant/src/esp_common.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/wpa_supplicant/esp_supplicant/src/esp_wps.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/wpa_supplicant/esp_supplicant/src/esp_wpa3.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/wpa_supplicant/esp_supplicant/src/esp_owe.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/wpa_supplicant/esp_supplicant/src/esp_hostap.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/wpa_supplicant/esp_supplicant/src/crypto/tls_mbedtls.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/wpa_supplicant/esp_supplicant/src/crypto/fastpbkdf2.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/wpa_supplicant/esp_supplicant/src/crypto/crypto_mbedtls.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/wpa_supplicant/esp_supplicant/src/crypto/crypto_mbedtls-bignum.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/wpa_supplicant/esp_supplicant/src/crypto/crypto_mbedtls-rsa.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/wpa_supplicant/esp_supplicant/src/crypto/crypto_mbedtls-ec.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/wpa_supplicant/src/crypto/rc4.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/wpa_supplicant/src/crypto/des-internal.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/wpa_supplicant/src/crypto/aes-wrap.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/wpa_supplicant/src/crypto/aes-unwrap.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/wpa_supplicant/src/crypto/aes-ccm.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/xtensa/eri.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/xtensa/xt_trax.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/xtensa/xtensa_context.S.o
+Compiling .pio/build/esp32-s3-ebook-librarian/xtensa/xtensa_intr_asm.S.o
+Archiving .pio/build/esp32-s3-ebook-librarian/esp-idf/wpa_supplicant/libwpa_supplicant.a
+Compiling .pio/build/esp32-s3-ebook-librarian/xtensa/xtensa_intr.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/xtensa/xtensa_vectors.S.o
+Indexing .pio/build/esp32-s3-ebook-librarian/esp-idf/wpa_supplicant/libwpa_supplicant.a
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/3rdparty/everest/library/everest.c.o
+Archiving .pio/build/esp32-s3-ebook-librarian/esp-idf/xtensa/libxtensa.a
+Indexing .pio/build/esp32-s3-ebook-librarian/esp-idf/xtensa/libxtensa.a
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/3rdparty/everest/library/x25519.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/3rdparty/everest/library/Hacl_Curve25519_joined.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/aes.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/aesni.c.o
+Archiving .pio/build/esp32-s3-ebook-librarian/esp-idf/mbedtls/mbedtls/3rdparty/everest/libeverest.a
+Indexing .pio/build/esp32-s3-ebook-librarian/esp-idf/mbedtls/mbedtls/3rdparty/everest/libeverest.a
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/aesce.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/aria.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/asn1parse.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/asn1write.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/base64.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/bignum.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/bignum_core.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/bignum_mod.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/bignum_mod_raw.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/block_cipher.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/camellia.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/ccm.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/chacha20.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/chachapoly.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/cipher.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/cipher_wrap.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/constant_time.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/cmac.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/ctr_drbg.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/des.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/dhm.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/ecdh.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/ecdsa.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/ecjpake.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/ecp.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/ecp_curves.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/ecp_curves_new.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/entropy.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/entropy_poll.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/error.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/gcm.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/hkdf.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/hmac_drbg.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/lmots.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/lms.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/md.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/md5.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/memory_buffer_alloc.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/nist_kw.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/oid.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/padlock.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/pem.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/pk.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/pk_ecc.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/pk_wrap.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/pkcs12.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/pkcs5.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/pkparse.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/pkwrite.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/platform.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/platform_util.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/poly1305.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/psa_crypto.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/psa_crypto_aead.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/psa_crypto_cipher.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/psa_crypto_client.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/psa_crypto_driver_wrappers_no_static.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/psa_crypto_ecp.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/psa_crypto_ffdh.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/psa_crypto_hash.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/psa_crypto_mac.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/psa_crypto_pake.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/psa_crypto_rsa.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/psa_crypto_se.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/psa_crypto_slot_management.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/psa_crypto_storage.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/psa_its_file.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/psa_util.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/ripemd160.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/rsa.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/rsa_alt_helpers.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/sha1.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/sha256.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/sha512.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/sha3.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/threading.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/timing.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/version.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/version_features.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/port/sha/dma/esp_sha_gdma_impl.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/port/aes/dma/esp_aes_gdma_impl.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/port/aes/dma/esp_aes_dma_core.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/port/crypto_shared_gdma/esp_crypto_shared_gdma.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/port/esp_hardware.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/port/esp_mem.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/port/esp_timing.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/port/aes/esp_aes_xts.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/port/aes/esp_aes_common.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/port/aes/dma/esp_aes.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/port/sha/esp_sha.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/port/sha/dma/sha.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/port/esp_ds/esp_rsa_sign_alt.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/port/bignum/esp_bignum.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/port/bignum/bignum_alt.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/port/sha/dma/esp_sha1.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/port/sha/dma/esp_sha256.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/port/sha/dma/esp_sha512.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/port/aes/esp_aes_gcm.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/port/md/esp_md.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/debug.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/mps_reader.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/mps_trace.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/ssl_cache.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/ssl_ciphersuites.c.o
+Archiving .pio/build/esp32-s3-ebook-librarian/esp-idf/mbedtls/mbedtls/library/libmbedcrypto.a
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/ssl_client.c.o
+Indexing .pio/build/esp32-s3-ebook-librarian/esp-idf/mbedtls/mbedtls/library/libmbedcrypto.a
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/ssl_cookie.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/ssl_debug_helpers_generated.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/ssl_msg.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/ssl_ticket.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/ssl_tls.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/ssl_tls12_client.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/ssl_tls12_server.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/ssl_tls13_keys.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/ssl_tls13_server.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/ssl_tls13_client.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/ssl_tls13_generic.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/port/mbedtls_debug.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/port/esp_platform_time.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/port/net_sockets.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/pkcs7.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/x509.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/x509_create.c.o
+Archiving .pio/build/esp32-s3-ebook-librarian/esp-idf/mbedtls/mbedtls/library/libmbedtls.a
+Indexing .pio/build/esp32-s3-ebook-librarian/esp-idf/mbedtls/mbedtls/library/libmbedtls.a
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/x509_crl.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/x509_crt.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/x509_csr.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/x509write.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/x509write_crt.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/library/x509write_csr.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/3rdparty/p256-m/p256-m_driver_entrypoints.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/mbedtls/mbedtls/3rdparty/p256-m/p256-m/p256-m.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/xtensa/eri.c.o
+Archiving .pio/build/esp32-s3-ebook-librarian/esp-idf/mbedtls/mbedtls/library/libmbedx509.a
+Archiving .pio/build/esp32-s3-ebook-librarian/esp-idf/mbedtls/mbedtls/3rdparty/p256-m/libp256m.a
+Indexing .pio/build/esp32-s3-ebook-librarian/esp-idf/mbedtls/mbedtls/3rdparty/p256-m/libp256m.a
+Indexing .pio/build/esp32-s3-ebook-librarian/esp-idf/mbedtls/mbedtls/library/libmbedx509.a
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/xtensa/xt_trax.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/bootloader/subproject/main/bootloader_start.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/bootloader_support/src/bootloader_common.c.o
+Archiving .pio/build/esp32-s3-ebook-librarian/bootloader/esp-idf/xtensa/libxtensa.a
+Indexing .pio/build/esp32-s3-ebook-librarian/bootloader/esp-idf/xtensa/libxtensa.a
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/bootloader_support/src/bootloader_common_loader.c.o
+Archiving .pio/build/esp32-s3-ebook-librarian/bootloader/esp-idf/main/libmain.a
+Indexing .pio/build/esp32-s3-ebook-librarian/bootloader/esp-idf/main/libmain.a
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/bootloader_support/src/bootloader_clock_init.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/bootloader_support/src/bootloader_mem.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/bootloader_support/src/bootloader_random.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/bootloader_support/src/bootloader_efuse.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/bootloader_support/src/flash_encrypt.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/bootloader_support/src/secure_boot.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/bootloader_support/src/bootloader_random_esp32s3.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/bootloader_support/bootloader_flash/src/bootloader_flash.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/bootloader_support/bootloader_flash/src/flash_qio_mode.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/bootloader_support/bootloader_flash/src/bootloader_flash_config_esp32s3.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/bootloader_support/src/bootloader_utility.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/bootloader_support/src/flash_partitions.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/bootloader_support/src/esp_image_format.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/bootloader_support/src/bootloader_init.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/bootloader_support/src/bootloader_clock_loader.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/bootloader_support/src/bootloader_console.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/bootloader_support/src/bootloader_console_loader.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/bootloader_support/src/esp32s3/bootloader_sha.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/bootloader_support/src/esp32s3/bootloader_soc.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/bootloader_support/src/esp32s3/bootloader_esp32s3.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/bootloader_support/src/bootloader_panic.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/efuse/esp32s3/esp_efuse_table.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/efuse/esp32s3/esp_efuse_fields.c.o
+Archiving .pio/build/esp32-s3-ebook-librarian/bootloader/esp-idf/bootloader_support/libbootloader_support.a
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/efuse/esp32s3/esp_efuse_rtc_calib.c.o
+Indexing .pio/build/esp32-s3-ebook-librarian/bootloader/esp-idf/bootloader_support/libbootloader_support.a
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/efuse/esp32s3/esp_efuse_utility.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/efuse/src/esp_efuse_api.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/efuse/src/esp_efuse_fields.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/efuse/src/esp_efuse_utility.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/efuse/src/efuse_controller/keys/with_key_purposes/esp_efuse_api_key.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/esp_bootloader_format/esp_bootloader_desc.c.o
+Archiving .pio/build/esp32-s3-ebook-librarian/bootloader/esp-idf/esp_bootloader_format/libesp_bootloader_format.a
+Indexing .pio/build/esp32-s3-ebook-librarian/bootloader/esp-idf/esp_bootloader_format/libesp_bootloader_format.a
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/esp_common/src/esp_err_to_name.c.o
+Archiving .pio/build/esp32-s3-ebook-librarian/bootloader/esp-idf/esp_common/libesp_common.a
+Indexing .pio/build/esp32-s3-ebook-librarian/bootloader/esp-idf/esp_common/libesp_common.a
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/esp_hw_support/cpu.c.o
+Archiving .pio/build/esp32-s3-ebook-librarian/bootloader/esp-idf/efuse/libefuse.a
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/esp_hw_support/port/esp32s3/esp_cpu_intr.c.o
+Indexing .pio/build/esp32-s3-ebook-librarian/bootloader/esp-idf/efuse/libefuse.a
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/esp_hw_support/esp_memory_utils.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/esp_hw_support/port/esp32s3/cpu_region_protect.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/esp_hw_support/port/esp32s3/rtc_clk.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/esp_hw_support/port/esp32s3/rtc_clk_init.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/esp_hw_support/port/esp32s3/rtc_init.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/esp_hw_support/port/esp32s3/rtc_sleep.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/esp_hw_support/port/esp32s3/rtc_time.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/esp_hw_support/port/esp32s3/chip_info.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/esp_rom/patches/esp_rom_sys.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/esp_rom/patches/esp_rom_print.c.o
+Archiving .pio/build/esp32-s3-ebook-librarian/bootloader/esp-idf/esp_hw_support/libesp_hw_support.a
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/esp_rom/patches/esp_rom_crc.c.o
+Indexing .pio/build/esp32-s3-ebook-librarian/bootloader/esp-idf/esp_hw_support/libesp_hw_support.a
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/esp_rom/patches/esp_rom_uart.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/esp_rom/patches/esp_rom_spiflash.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/esp_rom/patches/esp_rom_efuse.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/esp_rom/patches/esp_rom_gpio.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/esp_rom/patches/esp_rom_longjmp.S.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/esp_rom/patches/esp_rom_systimer.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/esp_rom/patches/esp_rom_wdt.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/esp_rom/patches/esp_rom_cache_esp32s2_esp32s3.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/esp_rom/patches/esp_rom_cache_writeback_esp32s3.S.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/esp_system/esp_err.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/hal/hal_utils.c.o
+Archiving .pio/build/esp32-s3-ebook-librarian/bootloader/esp-idf/esp_rom/libesp_rom.a
+Indexing .pio/build/esp32-s3-ebook-librarian/bootloader/esp-idf/esp_rom/libesp_rom.a
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/hal/mpu_hal.c.o
+Archiving .pio/build/esp32-s3-ebook-librarian/bootloader/esp-idf/esp_system/libesp_system.a
+Indexing .pio/build/esp32-s3-ebook-librarian/bootloader/esp-idf/esp_system/libesp_system.a
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/hal/efuse_hal.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/hal/esp32s3/efuse_hal.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/hal/mmu_hal.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/hal/cache_hal.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/log/src/noos/log_timestamp.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/log/src/log_timestamp_common.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/log/src/noos/log_lock.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/bootloader/subproject/components/micro-ecc/uECC_verify_antifault.c.o
+Archiving .pio/build/esp32-s3-ebook-librarian/bootloader/esp-idf/hal/libhal.a
+Archiving .pio/build/esp32-s3-ebook-librarian/bootloader/esp-idf/log/liblog.a
+Indexing .pio/build/esp32-s3-ebook-librarian/bootloader/esp-idf/hal/libhal.a
+Indexing .pio/build/esp32-s3-ebook-librarian/bootloader/esp-idf/log/liblog.a
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/soc/lldesc.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/soc/dport_access_common.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/soc/esp32s3/interrupts.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/soc/esp32s3/gpio_periph.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/soc/esp32s3/uart_periph.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/soc/esp32s3/adc_periph.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/soc/esp32s3/dedic_gpio_periph.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/soc/esp32s3/gdma_periph.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/soc/esp32s3/spi_periph.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/soc/esp32s3/ledc_periph.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/soc/esp32s3/pcnt_periph.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/soc/esp32s3/rmt_periph.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/soc/esp32s3/sdm_periph.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/soc/esp32s3/i2s_periph.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/soc/esp32s3/i2c_periph.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/soc/esp32s3/temperature_sensor_periph.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/soc/esp32s3/timer_periph.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/soc/esp32s3/lcd_periph.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/soc/esp32s3/mcpwm_periph.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/soc/esp32s3/mpi_periph.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/soc/esp32s3/sdmmc_periph.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/soc/esp32s3/touch_sensor_periph.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/soc/esp32s3/twai_periph.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/soc/esp32s3/wdt_periph.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/soc/esp32s3/usb_dwc_periph.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/soc/esp32s3/rtc_io_periph.c.o
+Compiling .pio/build/esp32-s3-ebook-librarian/bootloader/spi_flash/spi_flash_wrap.c.o
+Archiving .pio/build/esp32-s3-ebook-librarian/bootloader/esp-idf/soc/libsoc.a
+Archiving .pio/build/esp32-s3-ebook-librarian/bootloader/esp-idf/micro-ecc/libmicro-ecc.a
+Indexing .pio/build/esp32-s3-ebook-librarian/bootloader/esp-idf/micro-ecc/libmicro-ecc.a
+Indexing .pio/build/esp32-s3-ebook-librarian/bootloader/esp-idf/soc/libsoc.a
+Generating partitions .pio/build/esp32-s3-ebook-librarian/partitions.bin
+Generating an empty partition .pio/build/esp32-s3-ebook-librarian/ota_data_initial.bin
+Archiving .pio/build/esp32-s3-ebook-librarian/bootloader/esp-idf/spi_flash/libspi_flash.a
+Indexing .pio/build/esp32-s3-ebook-librarian/bootloader/esp-idf/spi_flash/libspi_flash.a
+Linking .pio/build/esp32-s3-ebook-librarian/bootloader.elf
+Building .pio/build/esp32-s3-ebook-librarian/bootloader.bin
+esptool.py v4.5.1
+Creating esp32s3 image...
+Merged 2 ELF sections
+Successfully created esp32s3 image.
+Archiving .pio/build/esp32-s3-ebook-librarian/esp-idf/sqlite3/libsqlite3.a
+Indexing .pio/build/esp32-s3-ebook-librarian/esp-idf/sqlite3/libsqlite3.a
+Generating project linker script .pio/build/esp32-s3-ebook-librarian/sections.ld
+Linking .pio/build/esp32-s3-ebook-librarian/firmware.elf
+Retrieving maximum program size .pio/build/esp32-s3-ebook-librarian/firmware.elf
+Checking size .pio/build/esp32-s3-ebook-librarian/firmware.elf
+Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
+RAM:   [==        ]  18.4% (used 60264 bytes from 327680 bytes)
+Flash: [======    ]  61.5% (used 1935916 bytes from 3145728 bytes)
+Building .pio/build/esp32-s3-ebook-librarian/firmware.bin
+esptool.py v4.5.1
+Creating esp32s3 image...
+Merged 3 ELF sections
+Successfully created esp32s3 image.
+========================= [SUCCESS] Took 99.05 seconds =========================
+Firmware compiled successfully!

--- a/main/main.c
+++ b/main/main.c
@@ -90,6 +90,9 @@
 #define NVS_NAMESPACE "wifi_creds"
 #define NVS_KEY_SSID "ssid"
 #define NVS_KEY_PASS "password"
+#define NVS_KEY_LED_R "led_r"
+#define NVS_KEY_LED_G "led_g"
+#define NVS_KEY_LED_B "led_b"
 
 
 // SD Card mount point and pin configuration
@@ -210,6 +213,11 @@ volatile bool g_cancel_transfer = false;
 volatile bool g_transfer_confirmed = false;
 volatile bool g_waiting_for_transfer_confirm = false;
 
+// Global LED colors
+uint8_t g_led_color_r = 255;
+uint8_t g_led_color_g = 255;
+uint8_t g_led_color_b = 255;
+
 
 // --- NVS Functions ---
 esp_err_t save_wifi_credentials(const char *ssid, const char *password) {
@@ -245,6 +253,30 @@ esp_err_t save_wifi_credentials(const char *ssid, const char *password) {
 
     nvs_close(my_handle);
     return err;
+}
+
+void load_led_color_from_nvs(void) {
+    nvs_handle_t my_handle;
+    esp_err_t err = nvs_open(NVS_NAMESPACE, NVS_READONLY, &my_handle);
+    if (err == ESP_OK) {
+        uint8_t r, g, b;
+        if (nvs_get_u8(my_handle, NVS_KEY_LED_R, &r) == ESP_OK) g_led_color_r = r;
+        if (nvs_get_u8(my_handle, NVS_KEY_LED_G, &g) == ESP_OK) g_led_color_g = g;
+        if (nvs_get_u8(my_handle, NVS_KEY_LED_B, &b) == ESP_OK) g_led_color_b = b;
+        nvs_close(my_handle);
+    }
+}
+
+void save_led_color_to_nvs(uint8_t r, uint8_t g, uint8_t b) {
+    nvs_handle_t my_handle;
+    esp_err_t err = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &my_handle);
+    if (err == ESP_OK) {
+        nvs_set_u8(my_handle, NVS_KEY_LED_R, r);
+        nvs_set_u8(my_handle, NVS_KEY_LED_G, g);
+        nvs_set_u8(my_handle, NVS_KEY_LED_B, b);
+        nvs_commit(my_handle);
+        nvs_close(my_handle);
+    }
 }
 
 esp_err_t load_wifi_credentials(char *ssid, size_t ssid_len, char *password, size_t pass_len) {
@@ -672,6 +704,38 @@ static esp_err_t list_files_handler(httpd_req_t *req) {
          return ESP_OK;
     }
 
+    if (strcmp(param, "sd") == 0) {
+        char catalog_path[256];
+        snprintf(catalog_path, sizeof(catalog_path), "%s/catalog.json", mount_path);
+        FILE *f = fopen(catalog_path, "r");
+        if (f) {
+            fseek(f, 0, SEEK_END);
+            long fsize = ftell(f);
+            fseek(f, 0, SEEK_SET);
+
+            char *json_data = malloc(fsize + 1);
+            if (json_data) {
+                fread(json_data, 1, fsize, f);
+                json_data[fsize] = '\0';
+                fclose(f);
+
+                httpd_resp_set_type(req, "application/json");
+                httpd_resp_send(req, json_data, fsize);
+
+                // Also broadcast the availability over LoRaWAN
+                #ifdef LORA_USE_SX1262
+                char lora_msg[128];
+                snprintf(lora_msg, sizeof(lora_msg), "Library active: catalog.json available.");
+                lora_wan_broadcast(lora_msg);
+                #endif
+
+                free(json_data);
+                return ESP_OK;
+            }
+            fclose(f);
+        }
+    }
+
     DIR *d = opendir(mount_path);
     if (!d) {
         ESP_LOGW(TAG, "Failed to open directory: %s", mount_path);
@@ -890,6 +954,38 @@ static esp_err_t sleep_handler(httpd_req_t *req) {
 }
 
 
+static esp_err_t set_led_color_handler(httpd_req_t *req) {
+    char content[100];
+    int ret = httpd_req_recv(req, content, sizeof(content) - 1);
+    if (ret <= 0) {
+        return ESP_FAIL;
+    }
+    content[ret] = '\0';
+
+    cJSON *json = cJSON_Parse(content);
+    if (!json) {
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid JSON");
+        return ESP_FAIL;
+    }
+
+    cJSON *r_item = cJSON_GetObjectItem(json, "r");
+    cJSON *g_item = cJSON_GetObjectItem(json, "g");
+    cJSON *b_item = cJSON_GetObjectItem(json, "b");
+
+    if (r_item && g_item && b_item) {
+        g_led_color_r = r_item->valueint;
+        g_led_color_g = g_item->valueint;
+        g_led_color_b = b_item->valueint;
+        save_led_color_to_nvs(g_led_color_r, g_led_color_g, g_led_color_b);
+        httpd_resp_send(req, "{\"success\":true}", 16);
+    } else {
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Missing RGB values");
+    }
+
+    cJSON_Delete(json);
+    return ESP_OK;
+}
+
 // --- WEB SERVER SETUP (MAIN APP) ---
 static httpd_handle_t start_webserver(void) {
     httpd_handle_t server = NULL;
@@ -924,6 +1020,9 @@ static httpd_handle_t start_webserver(void) {
 
         httpd_uri_t save_uri = { "/save-credentials", HTTP_POST, save_credentials_post_handler, NULL };
         httpd_register_uri_handler(server, &save_uri);
+
+        httpd_uri_t set_led_uri = { "/set-led-color", HTTP_POST, set_led_color_handler, NULL };
+        httpd_register_uri_handler(server, &set_led_uri);
 
         // Handler for all other URIs (serves static files)
         httpd_uri_t static_uri = { "/*", HTTP_GET, static_file_handler, NULL };
@@ -1660,7 +1759,7 @@ static void led_status_task(void *pvParameters) {
 
     while (1) {
         switch (g_led_state) {
-            case LED_STATE_IDLE: // Slow breathing white
+            case LED_STATE_IDLE: // Slow breathing custom color
                 if (increasing) {
                     brightness += 1;
                     if (brightness >= 80) increasing = false;
@@ -1669,8 +1768,11 @@ static void led_status_task(void *pvParameters) {
                     if (brightness <= 5) increasing = true;
                 }
                 for (int i = 0; i < LED_STRIP_LED_NUMBERS; i++) {
-                    // Set all LEDs to a white color with the current brightness
-                    led_strip_set_pixel(g_led_strip, i, brightness, brightness, brightness);
+                    // Set all LEDs to custom color with the current brightness scaling
+                    uint32_t r = (g_led_color_r * brightness) / 100;
+                    uint32_t g = (g_led_color_g * brightness) / 100;
+                    uint32_t b = (g_led_color_b * brightness) / 100;
+                    led_strip_set_pixel(g_led_strip, i, r, g, b);
                 }
                 led_strip_refresh(g_led_strip);
                 vTaskDelay(pdMS_TO_TICKS(35));
@@ -1896,6 +1998,8 @@ void app_main(void) {
       ret = nvs_flash_init();
     }
     ESP_ERROR_CHECK(ret);
+
+    load_led_color_from_nvs();
 
     app_event_queue = xQueueCreate(10, sizeof(app_event_queue_t));
     app_event_queue_t evt_queue;

--- a/main/web_assets/admin.html
+++ b/main/web_assets/admin.html
@@ -275,6 +275,20 @@ textarea.restore-area:focus { border-color: var(--accent-dark); }
     </div>
   </div>
 
+  <div class="section">
+    <div class="section-head">Lamp Color Control</div>
+    <div class="section-body">
+      <div class="row">
+        <div class="fld">
+          <label>Color</label>
+          <input type="color" id="lampColor" value="#ffffff" style="height:40px;width:60px;">
+        </div>
+        <button class="btn" onclick="doSetLampColor()">Set Lamp Color</button>
+      </div>
+      <div class="feedback" id="lampFb"></div>
+    </div>
+  </div>
+
 </div><!-- #panel -->
 
 <script>
@@ -431,6 +445,29 @@ async function deletePost(id) {
   } else {
     fb('postListFb', '✗ Delete failed');
   }
+}
+
+// ── Lamp Color ────────────────────────────────────────────────────────────────
+function doSetLampColor() {
+  const hex = document.getElementById('lampColor').value;
+  const r = parseInt(hex.substring(1, 3), 16);
+  const g = parseInt(hex.substring(3, 5), 16);
+  const b = parseInt(hex.substring(5, 7), 16);
+
+  fetch('/set-led-color', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ r, g, b })
+  })
+  .then(res => res.json())
+  .then(data => {
+    if (data.success) {
+      fb('lampFb', '✓ Lamp color updated');
+    } else {
+      fb('lampFb', '✗ Failed to update color');
+    }
+  })
+  .catch(() => fb('lampFb', '✗ Request failed'));
 }
 </script>
 </body>

--- a/main/web_assets/ereader.html
+++ b/main/web_assets/ereader.html
@@ -6,62 +6,96 @@
     <title>E-Book Library</title>
     <style>
         body {
-            font-family: sans-serif;
+            font-family: "Georgia", "Times New Roman", serif;
             margin: 0;
             padding: 10px;
-            background: #fff;
-            color: #000;
+            background: #2b211a;
+            color: #e8dbce;
         }
         h1 {
             text-align: center;
-            font-size: 1.5em;
+            font-size: 1.8em;
+            color: #ffcc80;
+            text-shadow: 0 0 10px rgba(255, 204, 128, 0.4);
+            border-bottom: 2px solid #5a4634;
+            padding-bottom: 10px;
+            margin-bottom: 20px;
         }
         .book-list {
             list-style: none;
             padding: 0;
             margin: 0;
+            max-width: 600px;
+            margin: 0 auto;
         }
         .book-item {
             margin-bottom: 15px;
-            padding: 10px;
-            border-bottom: 1px solid #ccc;
+            padding: 15px;
+            background-color: #3f3127;
+            border: 1px solid #5a4634;
+            border-radius: 8px;
+            box-shadow: 0 4px 10px rgba(0,0,0,0.5), 0 0 15px rgba(255, 180, 100, 0.1);
         }
         .book-title {
-            font-size: 1.2em;
+            font-size: 1.3em;
             font-weight: bold;
             margin-bottom: 5px;
             display: block;
             text-decoration: none;
-            color: #000;
+            color: #ffcc80;
+        }
+        .book-title:hover {
+            color: #ffe0b2;
+            text-shadow: 0 0 5px rgba(255, 204, 128, 0.5);
         }
         .book-author {
+            font-size: 1em;
+            color: #d1bfae;
+            font-style: italic;
+        }
+        .book-notes {
             font-size: 0.9em;
-            color: #555;
+            color: #a89f91;
+            margin-top: 8px;
+            line-height: 1.4;
         }
         .loading {
             text-align: center;
             font-style: italic;
+            color: #ffcc80;
         }
         .error {
-            color: red;
+            color: #ff8a80;
             text-align: center;
+            background-color: #3a2220;
+            padding: 10px;
+            border-radius: 5px;
+            border: 1px solid #5a2a25;
+            max-width: 600px;
+            margin: 0 auto;
         }
         .footer {
-            margin-top: 30px;
+            margin-top: 40px;
             text-align: center;
-            font-size: 0.8em;
-            color: #777;
+            font-size: 0.9em;
+            color: #8a7b6c;
             padding-bottom: 20px;
         }
         .admin-link {
             display: inline-block;
-            margin-top: 10px;
-            padding: 5px 10px;
-            background: #eee;
-            border: 1px solid #ccc;
+            margin-top: 15px;
+            padding: 8px 16px;
+            background: #8c5a35;
+            border: 1px solid #5a3820;
             text-decoration: none;
-            color: #333;
-            border-radius: 4px;
+            color: #f5eedc;
+            border-radius: 6px;
+            box-shadow: inset 0 1px 0 rgba(255,255,255,0.1), 0 1px 2px rgba(0,0,0,0.3);
+            transition: background-color 0.2s;
+        }
+        .admin-link:hover {
+            background-color: #a06b43;
+            box-shadow: inset 0 1px 0 rgba(255,255,255,0.2), 0 0 8px rgba(255, 204, 128, 0.4);
         }
     </style>
 </head>
@@ -69,7 +103,7 @@
 
     <h1>E-Book Library</h1>
 
-<div id="systemBanner" style="display:none;background:#ffcc00;color:#333;padding:10px;margin-bottom:15px;border-radius:5px;border:1px solid #e6b800;font-size:0.9em;">
+<div id="systemBanner" style="display:none;background:#8a6a24;color:#f5eedc;padding:10px;margin: 0 auto 20px auto;border-radius:5px;border:1px solid #a88532;font-size:0.9em;max-width:600px;box-shadow: 0 0 10px rgba(255, 200, 50, 0.2);">
     <ul id="systemErrorsList" style="margin:0;padding-left:20px;"></ul>
 </div>
     <div id="loading" class="loading">Loading books...</div>
@@ -134,7 +168,7 @@
             loadingElement.style.display = 'none';
 
             if (books.length === 0) {
-                listElement.innerHTML = '<li class="book-item">No books found in the library.</li>';
+                listElement.innerHTML = '<li class="book-item" style="text-align: center; color: #a89f91;">No books found in the library.</li>';
                 return;
             }
 
@@ -158,6 +192,13 @@
                     authorDiv.className = 'book-author';
                     authorDiv.textContent = `by ${book.author}`;
                     li.appendChild(authorDiv);
+                }
+
+                if (book.notes) {
+                    const notesDiv = document.createElement('div');
+                    notesDiv.className = 'book-notes';
+                    notesDiv.textContent = book.notes;
+                    li.appendChild(notesDiv);
                 }
 
                 listElement.appendChild(li);

--- a/main/web_assets/index.html
+++ b/main/web_assets/index.html
@@ -17,7 +17,7 @@
             <h1>E-Book Librarian</h1>
             <div class="status-indicator" :class="statusClass"></div>
         <div style="text-align: right; font-size: 1.1em; padding-bottom: 5px;">
-            <a href="/ereader.html" style="color: #007bff; text-decoration: underline; font-weight: bold;">Direct Download Mode</a>
+            <a href="/ereader.html" style="color: #ffcc80; text-decoration: underline; font-weight: bold;">Direct Download Mode</a>
         </div>
         </header>
         <main class="app-main">
@@ -28,6 +28,7 @@
                         <div class="file-info">
                             <span class="file-title">{{ file.title }}</span>
                             <span class="file-author">{{ file.author }}</span>
+                            <span v-if="file.notes" class="file-notes">{{ file.notes }}</span>
                         </div>
                         <div class="transfer-controls">
                             <div class="progress-container" v-if="transfer.active && transfer.filename === file.name">
@@ -47,6 +48,7 @@
                             <div class="file-info">
                                 <span class="file-title">{{ file.title }}</span>
                                 <span class="file-author">{{ file.author }}</span>
+                                <span v-if="file.notes" class="file-notes">{{ file.notes }}</span>
                             </div>
                             <div class="transfer-controls">
                                 <div class="progress-container" v-if="transfer.active && transfer.filename === file.name">

--- a/main/web_assets/style.css
+++ b/main/web_assets/style.css
@@ -1,94 +1,223 @@
-body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 0; background-color: #f0f2f5; color: #1c1e21; }
-.container { max-width: 900px; margin: 20px auto; padding: 20px; background-color: #fff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
-h1 { color: #1877f2; text-align: center; border-bottom: 1px solid #ddd; padding-bottom: 10px; }
-.status { padding: 10px; background-color: #e7f3ff; border: 1px solid #b7d9f7; border-radius: 6px; margin-bottom: 20px; text-align: center; }
-.status.connected { background-color: #e9f7ef; border-color: #b7e4c7; }
-.status.disconnected { background-color: #fff1f0; border-color: #ffccc7; }
-.panels { display: flex; flex-wrap: wrap; gap: 20px; }
-.panel { flex: 1; min-width: 300px; background: #f9f9f9; padding: 15px; border-radius: 6px; border: 1px solid #e0e0e0; }
-.panel h2 { margin-top: 0; font-size: 1.2em; }
-ul { list-style-type: none; padding: 0; max-height: 400px; overflow-y: auto; }
-li { padding: 8px 10px; border-bottom: 1px solid #eee; display: flex; align-items: center; justify-content: space-between; word-break: break-all; }
-li:last-child { border-bottom: none; }
-.file-info { flex-grow: 1; display: flex; flex-direction: column; }
-.file-title { font-weight: bold; }
-.file-author { font-style: italic; font-size: 0.9em; color: #555; }
-.file-name { cursor: pointer; }
-.file-name.selected { font-weight: bold; color: #1877f2; }
-button { background-color: #1877f2; color: white; border: none; padding: 10px 15px; border-radius: 6px; cursor: pointer; font-size: 1em; transition: background-color 0.2s; }
-button:disabled { background-color: #a0c3f7; cursor: not-allowed; }
-.actions { margin-top: 20px; text-align: center; }
-
+body {
+    font-family: "Georgia", "Times New Roman", serif;
+    margin: 0;
+    background-color: #2b211a;
+    color: #e8dbce;
+}
+.container {
+    max-width: 900px;
+    margin: 20px auto;
+    padding: 20px;
+    background-color: #3f3127;
+    border-radius: 12px;
+    box-shadow: 0 4px 15px rgba(0,0,0,0.5), 0 0 20px rgba(255, 180, 100, 0.15);
+    border: 1px solid #5a4634;
+}
+h1 {
+    color: #ffcc80;
+    text-align: center;
+    border-bottom: 2px solid #5a4634;
+    padding-bottom: 10px;
+    text-shadow: 0 0 10px rgba(255, 204, 128, 0.4);
+}
+h2 {
+    color: #e8dbce;
+}
+.app-header {
+    max-width: 900px;
+    margin: 20px auto;
+    padding: 20px;
+    background-color: #3f3127;
+    border-radius: 12px;
+    box-shadow: 0 4px 15px rgba(0,0,0,0.5), 0 0 20px rgba(255, 180, 100, 0.15);
+    border: 1px solid #5a4634;
+    text-align: center;
+}
+.app-main {
+    max-width: 900px;
+    margin: 20px auto;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+}
+.library-section, .ereader-section {
+    flex: 1;
+    min-width: 300px;
+    background: #3f3127;
+    padding: 20px;
+    border-radius: 12px;
+    border: 1px solid #5a4634;
+    box-shadow: 0 4px 15px rgba(0,0,0,0.5), 0 0 20px rgba(255, 180, 100, 0.15);
+}
+ul {
+    list-style-type: none;
+    padding: 0;
+    max-height: 400px;
+    overflow-y: auto;
+}
+li {
+    padding: 12px;
+    border-bottom: 1px solid #5a4634;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    word-break: break-all;
+    background-color: #352920;
+    margin-bottom: 8px;
+    border-radius: 8px;
+}
+li:last-child {
+    margin-bottom: 0;
+}
+.file-info {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+}
+.file-title {
+    font-weight: bold;
+    font-size: 1.1em;
+    color: #ffcc80;
+}
+.file-author {
+    font-style: italic;
+    font-size: 0.9em;
+    color: #d1bfae;
+}
+.file-notes {
+    font-size: 0.85em;
+    color: #a89f91;
+    margin-top: 4px;
+}
+button {
+    background-color: #8c5a35;
+    color: #f5eedc;
+    border: 1px solid #5a3820;
+    padding: 10px 15px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 1em;
+    transition: background-color 0.2s, box-shadow 0.2s;
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.1), 0 1px 2px rgba(0,0,0,0.3);
+}
+button:hover:not(:disabled) {
+    background-color: #a06b43;
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.2), 0 0 8px rgba(255, 204, 128, 0.4);
+}
+button:disabled {
+    background-color: #5a4634;
+    color: #8a7b6c;
+    cursor: not-allowed;
+    border-color: #4a382a;
+    box-shadow: none;
+}
 .transfer-controls {
     display: flex;
     align-items: center;
+    justify-content: space-between;
     gap: 10px;
+    width: 100%;
 }
-
 .progress-container {
-    width: 120px;
+    flex-grow: 1;
     height: 12px;
-    background-color: #e0e0e0;
+    background-color: #2b211a;
     border-radius: 6px;
     overflow: hidden;
+    border: 1px solid #5a4634;
 }
-
 .progress-bar {
     height: 100%;
-    background-color: #4a90e2;
+    background-color: #d98236;
     border-radius: 6px;
     transition: width 0.2s ease-in-out;
+    box-shadow: 0 0 10px rgba(217, 130, 54, 0.8);
 }
-
 button.cancel-btn {
-    background-color: #e74c3c;
+    background-color: #8b3a30;
+    border-color: #5a221b;
 }
-
 button.cancel-btn:hover {
-    background-color: #c0392b;
+    background-color: #a5463a;
+    box-shadow: 0 0 8px rgba(255, 100, 100, 0.4);
 }
-
 .app-footer {
-    background-color: #fce4e4;
-    color: #c0392b;
-    padding: 10px 25px;
+    max-width: 900px;
+    margin: 20px auto;
+    background-color: #3f3127;
+    color: #e8dbce;
+    padding: 15px 25px;
     text-align: center;
-    font-weight: bold;
+    border-radius: 12px;
+    border: 1px solid #5a4634;
+    box-shadow: 0 4px 15px rgba(0,0,0,0.5);
 }
-
 .error-message {
+    color: #ff8a80;
     margin: 0;
 }
-
 .footer-actions {
     padding-top: 10px;
     text-align: center;
 }
-
 .sleep-btn {
-    background-color: #c0392b;
-    color: white;
-    border: none;
-    padding: 8px 16px;
-    border-radius: 4px;
-    cursor: pointer;
-    font-size: 0.9em;
+    background-color: #6a403a;
 }
-
 .sleep-btn:hover {
-    background-color: #e74c3c;
+    background-color: #8c524a;
 }
-
 /* System Banner */
 .system-banner {
-    background-color: #ffcc00;
-    color: #333;
+    background-color: #8a6a24;
+    color: #f5eedc;
     padding: 10px;
     margin-bottom: 15px;
     border-radius: 5px;
-    border: 1px solid #e6b800;
+    border: 1px solid #a88532;
+    box-shadow: 0 0 10px rgba(255, 200, 50, 0.2);
 }
 .system-banner ul {
     margin: 0;
     padding-left: 20px;
+}
+.status-indicator {
+    width: 15px;
+    height: 15px;
+    border-radius: 50%;
+    display: inline-block;
+    margin-top: 10px;
+}
+.status-idle {
+    background-color: #ffcc80;
+    box-shadow: 0 0 10px #ffcc80;
+}
+.status-connected {
+    background-color: #81c784;
+    box-shadow: 0 0 10px #81c784;
+}
+.status-transferring {
+    background-color: #64b5f6;
+    box-shadow: 0 0 10px #64b5f6;
+}
+a {
+    color: #ffcc80;
+}
+a:hover {
+    color: #ffe0b2;
+    text-shadow: 0 0 5px rgba(255, 204, 128, 0.5);
+}
+/* Scrollbar styling */
+::-webkit-scrollbar {
+    width: 10px;
+}
+::-webkit-scrollbar-track {
+    background: #2b211a;
+    border-radius: 5px;
+}
+::-webkit-scrollbar-thumb {
+    background: #5a4634;
+    border-radius: 5px;
+}
+::-webkit-scrollbar-thumb:hover {
+    background: #7a5f47;
 }


### PR DESCRIPTION
This PR introduces several UI and UX features inspired by the "Banned Book Library" concept:
1. **Cozy UI:** Replaced the default flat blue/white UI with a warm, "glowy" color scheme (sepia tones, oranges, dark browns) and subtle drop shadows to evoke the feeling of a cozy library lamp.
2. **Central Catalog Support:** The system now checks for `catalog.json` on the SD card when listing files, allowing the frontend to quickly pull enriched metadata (like custom `notes` and file hashes) instead of relying solely on filenames.
3. **LoRaWAN Broadcasting:** Added a short LoRaWAN broadcast notification (`Library active: catalog.json available.`) to alert nearby devices of the catalog's availability without overwhelming the LoRaWAN constraints.
4. **Lamp Color API:** Implemented a new API (`/set-led-color`) to set the idle LED color of the smart bulb. This value is persisted via NVS so the device remembers the custom lamp color across reboots. This allows users to blend the dead drop into its physical environment.
5. **Admin Controls:** Added a simple color picker to the Admin UI (`admin.html`) to interact with the new LED color API.

---
*PR created automatically by Jules for task [10120172838410851270](https://jules.google.com/task/10120172838410851270) started by @LokiMetaSmith*