### PR TITLE
Fix SD card initialization timeout and enable formatting

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -1539,7 +1539,7 @@ void init_spiffs(void) {
 void init_sd_card(void) {
     esp_err_t ret;
     esp_vfs_fat_sdmmc_mount_config_t mount_config = {
-        .format_if_mount_failed = false,
+        .format_if_mount_failed = true,
         .max_files = 5,
         .allocation_unit_size = 16 * 1024
     };
@@ -1554,6 +1554,10 @@ void init_sd_card(void) {
         .sclk_io_num = PIN_NUM_CLK,
         .quadwp_io_num = -1,
         .quadhd_io_num = -1,
+        .data4_io_num = -1,
+        .data5_io_num = -1,
+        .data6_io_num = -1,
+        .data7_io_num = -1,
         .max_transfer_sz = 4000,
     };
     // Ensure SPI3 is used for SD card to avoid conflict with LoRa on SPI2


### PR DESCRIPTION
This resolves the 0x108 initialization error for the SD card module. The ESP-IDF zero-initializes the `spi_bus_config_t` struct, which causes unused data pins to map to GPIO 0. GPIO 0 is used as a strapping pin and physical button, so having the SPI driver claim it causes timeouts. This fix explicitly ignores those unused pins and also allows the device to format unformatted cards.

---
*PR created automatically by Jules for task [4897880053987558070](https://jules.google.com/task/4897880053987558070) started by @LokiMetaSmith*