### PR TITLE
Fix infinite redirect loop for missing root files

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,16 @@ This project is built using the **Espressif IoT Development Framework (ESP-IDF)*
     - Save and exit.
 
 4.  **Build, Flash, and Monitor:**
-    Connect your ESP32-S3 board and run the following command to build the project, upload it to the device, and view the serial output:
+    Connect your ESP32-S3 board. Because the web UI is stored on a separate filesystem (SPIFFS), you must flash both the application and the `storage` partition.
+
+    You can use the provided script on Linux/macOS:
     ```bash
-    idf.py build flash monitor
+    ./install_firmware.sh
+    ```
+
+    Or run the commands manually (required on Windows):
+    ```bash
+    idf.py build storage-flash flash monitor
     ```
 
 ## 💻 Usage

--- a/install_firmware.sh
+++ b/install_firmware.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -e
+
+echo "==============================================="
+echo " E-Book Librarian - Firmware Installer"
+echo "==============================================="
+
+# Check if idf.py is in the PATH
+if ! command -v idf.py &> /dev/null; then
+    echo "Error: idf.py could not be found."
+    echo "Please ensure you have set up the ESP-IDF environment."
+    echo "Run '. <path-to-esp-idf>/export.sh' or use the VS Code extension terminal."
+    exit 1
+fi
+
+echo "Building firmware..."
+idf.py build
+
+echo "Flashing SPIFFS partition (web assets)..."
+idf.py storage-flash
+
+echo "Flashing main firmware and opening monitor..."
+idf.py flash monitor

--- a/main/main.c
+++ b/main/main.c
@@ -516,6 +516,13 @@ static esp_err_t static_file_handler(httpd_req_t *req) {
     struct stat path_stat;
     if (stat(filepath, &path_stat) == -1) {
         ESP_LOGE(TAG, "File not found: %s", filepath);
+
+        // Prevent infinite redirect loops for core endpoints
+        if (strcmp(req->uri, "/") == 0 || strcmp(req->uri, "/index.html") == 0 || strcmp(req->uri, "/ereader.html") == 0) {
+            httpd_resp_send_404(req);
+            return ESP_FAIL;
+        }
+
         // Instead of 404, redirect to root for captive portal functionality
         httpd_resp_set_status(req, "302 Temporary Redirect");
         httpd_resp_set_hdr(req, "Location", "/");


### PR DESCRIPTION
The captive portal handles requests to missing files by redirecting to `/` to serve the setup page or library application. However, when the SPIFFS partition is unmounted or missing, requesting `/` would map to `index.html`, fail to find it, and redirect back to `/`, causing an infinite loop. This patch breaks the loop by returning a `404 Not Found` specifically for root and core application files when they are absent.

---
*PR created automatically by Jules for task [4006431030621572795](https://jules.google.com/task/4006431030621572795) started by @LokiMetaSmith*