### PR TITLE
⚡ Bolt: Render board sorting locally to save network requests

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-19 - Pure UI State Reloading Data
+**Learning:** In standard HTML/JS applications without reactive frameworks, UI sorting actions (like clicking "New" or "Expiring") can easily be hardcoded to trigger redundant full data reloads (e.g., `load(); loadSystemStatus();`) instead of re-rendering cached data. This causes severe, unnecessary backend load and UI latency for simple list sorts.
+**Action:** When inspecting client-side sorting and filtering, check if the data is being fetched anew. Always reuse cached data (e.g., `lastData`) for operations that only change the presentation order.

--- a/main/web_assets/board.html
+++ b/main/web_assets/board.html
@@ -508,8 +508,9 @@ function setSort(s, btn) {
   activeSort = s;
   document.getElementById('sNew').classList.toggle('active', s === 'new');
   document.getElementById('sExp').classList.toggle('active', s === 'exp');
-  load();
-  loadSystemStatus();
+
+  // ⚡ Bolt: Render locally instead of fetching from server to save 2 network requests
+  if (lastData.length) render(lastData);
 }
 
 // ── Data ───────────────────────────────────────


### PR DESCRIPTION
💡 **What**: Modified the `setSort` function in `main/web_assets/board.html` to re-render locally cached data (`lastData`) instead of triggering full data reloads from the ESP32 backend.

🎯 **Why**: Changing the sort order (New vs Expiring) shouldn't require re-fetching all messages and system status from the server. This reduces unnecessary backend load on the ESP32 and eliminates UI latency when interacting with the board.

📊 **Impact**: Saves 2 HTTP requests (`/board/messages` and `/status`) every time a user changes the sort order. Sorting is now instant and runs completely client-side.

🔬 **Measurement**: Verify by opening the Network tab in browser dev tools. Clicking "New" or "Expiring" on the Community Hub board will no longer trigger any XHR requests, but the UI will update instantly.

Added a learning about avoiding redundant data fetching for pure UI state changes in `.Jules/bolt.md`.

---
*PR created automatically by Jules for task [3896525903926234267](https://jules.google.com/task/3896525903926234267) started by @LokiMetaSmith*