### PR TITLE
🛡️ Sentinel: [HIGH] Fix Null Pointer Deref and Path Traversal in File Transfer

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-14 - cJSON Null Pointer Dereference in Handlers
+**Vulnerability:** Null Pointer Dereference (DoS) and Path Traversal
+**Learning:** ESP-IDF HTTP handlers using `cJSON` must explicitly check that `cJSON_GetObjectItem(json, "key")` does not return NULL before attempting to access its properties like `->valuestring`. Failing to do so causes a hard crash when malformed payloads are received. Additionally, VFS operations in ESP-IDF require manual path traversal checks (e.g. `strstr(filename, "..")`).
+**Prevention:** Always check both the item and its specific value field for NULL, and manually validate inputs used in file system paths.

--- a/main/main.c
+++ b/main/main.c
@@ -842,13 +842,27 @@ static esp_err_t transfer_file_handler(httpd_req_t *req) {
         return ESP_FAIL;
     }
 
-    const char *source = cJSON_GetObjectItem(json, "source")->valuestring;
-    const char *destination = cJSON_GetObjectItem(json, "destination")->valuestring;
-    const char *filename = cJSON_GetObjectItem(json, "filename")->valuestring;
+    cJSON *j_source = cJSON_GetObjectItem(json, "source");
+    cJSON *j_destination = cJSON_GetObjectItem(json, "destination");
+    cJSON *j_filename = cJSON_GetObjectItem(json, "filename");
 
-    if (!source || !destination || !filename) {
+    if (!j_source || !j_source->valuestring ||
+        !j_destination || !j_destination->valuestring ||
+        !j_filename || !j_filename->valuestring) {
         cJSON_Delete(json);
         httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Bad Request");
+        g_led_state = ebook_reader_connected ? LED_STATE_CONNECTED : LED_STATE_IDLE;
+        return ESP_FAIL;
+    }
+
+    const char *source = j_source->valuestring;
+    const char *destination = j_destination->valuestring;
+    const char *filename = j_filename->valuestring;
+
+    // Basic path traversal prevention
+    if (strstr(filename, "..") != NULL) {
+        cJSON_Delete(json);
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid Filename");
         g_led_state = ebook_reader_connected ? LED_STATE_CONNECTED : LED_STATE_IDLE;
         return ESP_FAIL;
     }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `transfer_file_handler` in `main.c` was vulnerable to a Denial of Service (DoS) attack via a Null Pointer Dereference when parsing malformed JSON payloads, and lacked Path Traversal protection for the filename parameter.
🎯 Impact: An attacker could crash the ESP32 server by sending a POST request missing the `source`, `destination`, or `filename` keys. Furthermore, they could potentially read/write arbitrary files using `../` in the filename.
🔧 Fix: Added explicit NULL checks for `cJSON_GetObjectItem()` return values and implemented a `strstr(filename, "..")` check to prevent directory traversal.
✅ Verification: Build passes successfully. Code review verified the fix as correct and safe.

---
*PR created automatically by Jules for task [12723864781243398646](https://jules.google.com/task/12723864781243398646) started by @LokiMetaSmith*