### PR TITLE
feat: Add hardware key authentication via USB mass storage

### DIFF
--- a/main/bulletin_api.c
+++ b/main/bulletin_api.c
@@ -135,7 +135,8 @@ static esp_err_t admin_auth_handler(httpd_req_t *req) {
     return ESP_OK;
 }
 
-static bool check_admin_token(httpd_req_t *req) {
+bool bb_is_admin_request(httpd_req_t *req) {
+    if (g_hardware_key_authenticated) return true;
     char buf[128];
     if (httpd_req_get_url_query_str(req, buf, sizeof(buf)) == ESP_OK) {
         char token[33];
@@ -146,13 +147,22 @@ static bool check_admin_token(httpd_req_t *req) {
     return false;
 }
 
+static esp_err_t admin_auth_status_handler(httpd_req_t *req) {
+    if (bb_is_admin_request(req)) {
+        httpd_resp_send(req, "{\"authenticated\": true}", 23);
+        return ESP_OK;
+    }
+    httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "forbidden");
+    return ESP_FAIL;
+}
+
 static esp_err_t admin_identity_get_handler(httpd_req_t *req) {
-    if (!check_admin_token(req)) { httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "forbidden"); return ESP_FAIL; }
+    if (!bb_is_admin_request(req)) { httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "forbidden"); return ESP_FAIL; }
     return board_info_handler(req);
 }
 
 static esp_err_t admin_identity_set_handler(httpd_req_t *req) {
-    if (!check_admin_token(req)) { httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "forbidden"); return ESP_FAIL; }
+    if (!bb_is_admin_request(req)) { httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "forbidden"); return ESP_FAIL; }
     
     char buf[512];
     if (httpd_req_get_url_query_str(req, buf, sizeof(buf)) == ESP_OK) {
@@ -171,7 +181,7 @@ static esp_err_t admin_identity_set_handler(httpd_req_t *req) {
 }
 
 static esp_err_t admin_setkey_handler(httpd_req_t *req) {
-    if (!check_admin_token(req)) { httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "forbidden"); return ESP_FAIL; }
+    if (!bb_is_admin_request(req)) { httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "forbidden"); return ESP_FAIL; }
     
     char buf[128];
     if (httpd_req_get_url_query_str(req, buf, sizeof(buf)) == ESP_OK) {
@@ -188,14 +198,14 @@ static esp_err_t admin_setkey_handler(httpd_req_t *req) {
 }
 
 static esp_err_t admin_clear_handler(httpd_req_t *req) {
-    if (!check_admin_token(req)) { httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "forbidden"); return ESP_FAIL; }
+    if (!bb_is_admin_request(req)) { httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "forbidden"); return ESP_FAIL; }
     bb_clear_messages();
     httpd_resp_send(req, "cleared", 7);
     return ESP_OK;
 }
 
 static esp_err_t admin_delete_post_handler(httpd_req_t *req) {
-    if (!check_admin_token(req)) { httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "forbidden"); return ESP_FAIL; }
+    if (!bb_is_admin_request(req)) { httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "forbidden"); return ESP_FAIL; }
     
     char buf[128];
     if (httpd_req_get_url_query_str(req, buf, sizeof(buf)) == ESP_OK) {
@@ -223,6 +233,9 @@ void register_bulletin_api_handlers(httpd_handle_t server) {
 
     httpd_uri_t admin_auth_uri = { .uri = "/board/admin/auth", .method = HTTP_POST, .handler = admin_auth_handler, .user_ctx = NULL };
     httpd_register_uri_handler(server, &admin_auth_uri);
+
+    httpd_uri_t admin_auth_status_uri = { .uri = "/board/admin/auth/status", .method = HTTP_GET, .handler = admin_auth_status_handler, .user_ctx = NULL };
+    httpd_register_uri_handler(server, &admin_auth_status_uri);
 
     httpd_uri_t admin_id_get_uri = { .uri = "/board/admin/identity/get", .method = HTTP_GET, .handler = admin_identity_get_handler, .user_ctx = NULL };
     httpd_register_uri_handler(server, &admin_id_get_uri);

--- a/main/bulletin_api.h
+++ b/main/bulletin_api.h
@@ -7,6 +7,9 @@
 extern "C" {
 #endif
 
+// Check if request has an admin token or if the hardware key is present
+bool bb_is_admin_request(httpd_req_t *req);
+
 // Register the handlers with the given web server instance
 void register_bulletin_api_handlers(httpd_handle_t server);
 

--- a/main/bulletin_board.c
+++ b/main/bulletin_board.c
@@ -24,6 +24,7 @@ char id_footer[101]  = "Powered locally — no internet required";
 char admin_key[65]   = "change_me";
 char session_token[33] = "";
 unsigned long token_issued_at = 0;
+bool g_hardware_key_authenticated = false;
 
 int msgCount = 0;
 uint16_t nextMsgId = 1;

--- a/main/bulletin_board.h
+++ b/main/bulletin_board.h
@@ -26,6 +26,7 @@ extern char id_footer[101];
 extern char admin_key[65];
 extern char session_token[33];
 extern unsigned long token_issued_at;
+extern bool g_hardware_key_authenticated;
 
 extern int msgCount;
 extern BulletinMessage msgs[MAX_MSGS];

--- a/main/main.c
+++ b/main/main.c
@@ -49,6 +49,7 @@
 #include "sdmmc_cmd.h"
 #include "cJSON.h"
 #include "lorawan.h"
+#include "bulletin_board.h"
 #include "bulletin_api.h"
 
 // --- Local Dependencies ---
@@ -991,6 +992,11 @@ static esp_err_t sleep_handler(httpd_req_t *req) {
 
 
 static esp_err_t set_led_color_handler(httpd_req_t *req) {
+    if (!bb_is_admin_request(req)) {
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Forbidden");
+        return ESP_FAIL;
+    }
+
     char content[100];
     int ret = httpd_req_recv(req, content, sizeof(content) - 1);
     if (ret <= 0) {
@@ -1754,6 +1760,28 @@ static void msc_event_cb(const msc_host_event_t *event, void *arg)
         // Mount the filesystem
         if (msc_host_vfs_register(device_handle, MOUNT_POINT_USB, &msc_mount_config, &vfs_handle) == ESP_OK) {
             ESP_LOGI(TAG, "MSC device mounted at %s", MOUNT_POINT_USB);
+
+            // Check for hardware auth key file
+            char key_file_path[128];
+            snprintf(key_file_path, sizeof(key_file_path), "%s/.library_admin.key", MOUNT_POINT_USB);
+            FILE *kf = fopen(key_file_path, "r");
+            if (kf) {
+                char key_buf[65] = {0};
+                size_t read_bytes = fread(key_buf, 1, 64, kf);
+                fclose(kf);
+                if (read_bytes > 0) {
+                    // trim trailing whitespace
+                    while (read_bytes > 0 && isspace((unsigned char)key_buf[read_bytes-1])) {
+                        key_buf[read_bytes-1] = '\0';
+                        read_bytes--;
+                    }
+                    if (bb_check_key(key_buf)) {
+                        g_hardware_key_authenticated = true;
+                        ESP_LOGI(TAG, "Hardware admin key authenticated via USB");
+                    }
+                }
+            }
+
             // Attempt to import from Calibre DB
             import_from_calibre_db(MOUNT_POINT_USB);
         } else {
@@ -1764,6 +1792,7 @@ static void msc_event_cb(const msc_host_event_t *event, void *arg)
     } else if (event->event == MSC_DEVICE_DISCONNECTED) {
         ESP_LOGI(TAG, "MSC device disconnected");
         ebook_reader_connected = false;
+        g_hardware_key_authenticated = false;
         g_led_state = LED_STATE_IDLE;
         // Unmount the filesystem
         msc_host_vfs_unregister(vfs_handle);

--- a/main/web_assets/admin.html
+++ b/main/web_assets/admin.html
@@ -294,6 +294,37 @@ textarea.restore-area:focus { border-color: var(--accent-dark); }
 <script>
 let SESSION_TOKEN = '';
 
+// ── Hardware Auth Check ────────────────────────────────────────────────────
+window.addEventListener('DOMContentLoaded', () => {
+  fetch('/board/admin/auth/status')
+    .then(r => {
+        if (!r.ok) throw new Error('Not authenticated');
+        return r.json();
+    })
+    .then(data => {
+      if (data.authenticated) {
+        document.getElementById('gate').style.display  = 'none';
+        document.getElementById('panel').style.display = 'block';
+        loadAdminData();
+      }
+    })
+    .catch(e => console.log('Hardware auth not present.'));
+});
+
+function loadAdminData() {
+  // Load identity info
+  apiFetch(api('/board/admin/identity/get'))
+    .then(r => r.json())
+    .then(d => {
+      document.getElementById('idName').value = d.name || '';
+      document.getElementById('idIcon').value = d.icon || '';
+      document.getElementById('idTagline').value = d.tagline || '';
+      document.getElementById('idRules').value = d.rules || '';
+      document.getElementById('idFooter').value = d.footer || '';
+    });
+  loadPostList();
+}
+
 // ── Gate ────────────────────────────────────────────────────────────────────
 function tryLogin() {
   const val = document.getElementById('keyIn').value;
@@ -311,19 +342,7 @@ function tryLogin() {
     SESSION_TOKEN = token;
     document.getElementById('gate').style.display  = 'none';
     document.getElementById('panel').style.display = 'block';
-    
-    // Load identity info
-    apiFetch(api('/board/admin/identity/get'))
-      .then(r => r.json())
-      .then(d => {
-        document.getElementById('idName').value = d.name || '';
-        document.getElementById('idIcon').value = d.icon || '';
-        document.getElementById('idTagline').value = d.tagline || '';
-        document.getElementById('idRules').value = d.rules || '';
-        document.getElementById('idFooter').value = d.footer || '';
-      });
-
-    loadPostList();
+    loadAdminData();
   })
   .catch(() => {
     document.getElementById('gateErr').textContent = 'Incorrect key.';


### PR DESCRIPTION
This PR implements the requested FIDO-like security fob feature by using standard USB Mass Storage devices.

### What it does:
- Introduces physical hardware authentication via USB.
- Looks for a hidden `.library_admin.key` file upon USB insertion and compares its contents to the device's secure `admin_key`.
- Modifies all backend `/admin` endpoints (including the LED configuration) to enforce this authentication check.
- Updates the `admin.html` frontend to skip the password prompt entirely if the hardware key is currently connected to the device, enabling a seamless passwordless login experience.
- Instantly revokes admin privileges the moment the USB drive is unplugged.

### Why it is implemented this way:
Implementing standard FIDO U2F/CTAP protocols over USB HID on the ESP32 is complex and prone to edge-case bugs. A file-based check on top of the already robust MSC USB implementation provides an extremely reliable, easy-to-use "hardware fob" feature while utilizing the existing stable infrastructure.

---
*PR created automatically by Jules for task [727677675739721058](https://jules.google.com/task/727677675739721058) started by @LokiMetaSmith*