### PR TITLE
feat: Add SD Card Format endpoint to Admin UI and backend

### DIFF
--- a/build_output.log
+++ b/build_output.log
@@ -1,0 +1,38 @@
+Setting up ESP32 Dev Environment and PlatformIO...
+Ensuring platformio is installed in the virtual environment...
+
+[notice] A new release of pip is available: 25.0.1 -> 26.1.2
+[notice] To update, run: /app/.venv/bin/python -m pip install --upgrade pip
+Building firmware with PlatformIO...
+Processing esp32-s3-ebook-librarian (platform: espressif32@6.11.0; framework: espidf; board: esp32s3usbotg)
+--------------------------------------------------------------------------------
+Verbose mode can be enabled via `-v, --verbose` option
+CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32s3usbotg.html
+PLATFORM: Espressif 32 (6.11.0) > Espressif ESP32-S3-USB-OTG
+HARDWARE: ESP32S3 240MHz, 320KB RAM, 8MB Flash
+DEBUG: Current (esp-builtin) On-board (esp-builtin) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+PACKAGES:
+ - framework-espidf @ 3.50401.0 (5.4.1)
+ - tool-cmake @ 3.16.4
+ - tool-esp-rom-elfs @ 0.0.1+20241011
+ - tool-esptoolpy @ 1.40501.0 (4.5.1)
+ - tool-ninja @ 1.7.1
+ - tool-riscv32-esp-elf-gdb @ 12.1.0+20221002
+ - tool-xtensa-esp-elf-gdb @ 12.1.0+20221002
+ - toolchain-esp32ulp @ 1.23800.240113 (2.38.0)
+ - toolchain-riscv32-esp @ 14.2.0+20241119
+ - toolchain-xtensa-esp-elf @ 14.2.0+20241119
+Reading CMake configuration...
+LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+LDF Modes: Finder ~ chain, Compatibility ~ soft
+Found 0 compatible libraries
+Scanning dependencies...
+No dependencies
+Building in release mode
+Retrieving maximum program size .pio/build/esp32-s3-ebook-librarian/firmware.elf
+Checking size .pio/build/esp32-s3-ebook-librarian/firmware.elf
+Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
+RAM:   [====      ]  39.8% (used 130360 bytes from 327680 bytes)
+Flash: [======    ]  61.7% (used 1942348 bytes from 3145728 bytes)
+========================= [SUCCESS] Took 9.14 seconds =========================
+Firmware compiled successfully!

--- a/main/bulletin_api.c
+++ b/main/bulletin_api.c
@@ -211,6 +211,20 @@ static esp_err_t admin_delete_post_handler(httpd_req_t *req) {
     return ESP_FAIL;
 }
 
+extern bool format_sd_card(void);
+
+static esp_err_t admin_format_sd_handler(httpd_req_t *req) {
+    if (!check_admin_token(req)) { httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "forbidden"); return ESP_FAIL; }
+
+    if (format_sd_card()) {
+        httpd_resp_send(req, "formatted", 9);
+        return ESP_OK;
+    } else {
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+}
+
 void register_bulletin_api_handlers(httpd_handle_t server) {
     httpd_uri_t info_uri = { .uri = "/board/info", .method = HTTP_GET, .handler = board_info_handler, .user_ctx = NULL };
     httpd_register_uri_handler(server, &info_uri);
@@ -238,4 +252,7 @@ void register_bulletin_api_handlers(httpd_handle_t server) {
 
     httpd_uri_t admin_del_uri = { .uri = "/board/admin/delete/post", .method = HTTP_GET, .handler = admin_delete_post_handler, .user_ctx = NULL };
     httpd_register_uri_handler(server, &admin_del_uri);
+
+    httpd_uri_t admin_format_sd_uri = { .uri = "/board/admin/format-sd", .method = HTTP_POST, .handler = admin_format_sd_handler, .user_ctx = NULL };
+    httpd_register_uri_handler(server, &admin_format_sd_uri);
 }

--- a/main/main.c
+++ b/main/main.c
@@ -170,6 +170,7 @@ static led_strip_handle_t g_led_strip;
 static bool g_wifi_configured = false;
 bool g_usb_mounted = false;
 bool g_sd_card_initialized = false;
+sdmmc_card_t *g_sd_card_handle = NULL;
 extern bool lora_initialized;
 QueueHandle_t app_event_queue = NULL;
 
@@ -1564,7 +1565,6 @@ void init_sd_card(void) {
         .max_files = 5,
         .allocation_unit_size = 16 * 1024
     };
-    sdmmc_card_t *card;
     const char mount_point[] = MOUNT_POINT_SD;
     ESP_LOGI(TAG, "Initializing SD card");
 
@@ -1602,7 +1602,7 @@ void init_sd_card(void) {
     slot_config.gpio_cs = PIN_NUM_CS;
     slot_config.host_id = host.slot;
 
-    ret = esp_vfs_fat_sdspi_mount(mount_point, &host, &slot_config, &mount_config, &card);
+    ret = esp_vfs_fat_sdspi_mount(mount_point, &host, &slot_config, &mount_config, &g_sd_card_handle);
 
     if (ret != ESP_OK) {
         ESP_LOGW(TAG, "Failed to mount SD card VFS (soft fail)");
@@ -1610,6 +1610,29 @@ void init_sd_card(void) {
     } else {
         ESP_LOGI(TAG, "SD card mounted successfully at %s", mount_point);
         g_sd_card_initialized = true;
+    }
+}
+
+bool format_sd_card(void) {
+    if (!g_sd_card_initialized || g_sd_card_handle == NULL) {
+        ESP_LOGW(TAG, "Cannot format SD card: Not initialized or not mounted.");
+        return false;
+    }
+
+    esp_vfs_fat_sdmmc_mount_config_t mount_config = {
+        .format_if_mount_failed = true,
+        .max_files = 5,
+        .allocation_unit_size = 16 * 1024
+    };
+
+    ESP_LOGI(TAG, "Explicitly formatting SD card...");
+    esp_err_t err = esp_vfs_fat_sdcard_format_cfg(MOUNT_POINT_SD, g_sd_card_handle, &mount_config);
+    if (err == ESP_OK) {
+        ESP_LOGI(TAG, "SD Card formatted successfully!");
+        return true;
+    } else {
+        ESP_LOGE(TAG, "Failed to format SD card: %s", esp_err_to_name(err));
+        return false;
     }
 }
 

--- a/main/web_assets/admin.html
+++ b/main/web_assets/admin.html
@@ -289,6 +289,16 @@ textarea.restore-area:focus { border-color: var(--accent-dark); }
     </div>
   </div>
 
+  <div class="section">
+    <div class="section-head">Storage Management</div>
+    <div class="section-body">
+      <div class="row">
+        <button class="btn danger" onclick="confirmFormatSD()">Format SD Card</button>
+      </div>
+      <div class="feedback" id="storageFb"></div>
+    </div>
+  </div>
+
 </div><!-- #panel -->
 
 <script>
@@ -445,6 +455,21 @@ async function deletePost(id) {
   } else {
     fb('postListFb', '✗ Delete failed');
   }
+}
+
+// ── Storage Management ────────────────────────────────────────────────────────
+function confirmFormatSD() {
+  if (!confirm('Are you sure you want to format the SD card? All data will be lost.')) return;
+
+  apiFetch(api('/board/admin/format-sd'), { method: 'POST' })
+    .then(r => {
+      if (r.ok) {
+        fb('storageFb', '✓ SD Card formatted successfully');
+      } else {
+        fb('storageFb', '✗ Failed to format SD Card');
+      }
+    })
+    .catch(() => fb('storageFb', '✗ Request failed'));
 }
 
 // ── Lamp Color ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
The user requested verification of SD card error mitigations and the addition of a runtime format capability. I have added the manual formatting function to `main.c`, created a new protected API endpoint, and updated the admin web panel with a button. I've also verified the `0x107` error mitigations are already implemented correctly in the codebase. Pre-commit checks, code review, and frontend verification were fully executed.

---
*PR created automatically by Jules for task [4041364443613926338](https://jules.google.com/task/4041364443613926338) started by @LokiMetaSmith*