### PR TITLE
Fix text formatting loss on admin identity settings save

### DIFF
--- a/main/bulletin_api.c
+++ b/main/bulletin_api.c
@@ -179,11 +179,11 @@ static esp_err_t admin_identity_set_handler(httpd_req_t *req) {
     char buf[512];
     if (httpd_req_get_url_query_str(req, buf, sizeof(buf)) == ESP_OK) {
         char temp[101];
-        if (httpd_query_key_value(buf, "name", temp, sizeof(temp)) == ESP_OK) sanitize(temp, id_name, 49);
-        if (httpd_query_key_value(buf, "icon", temp, sizeof(temp)) == ESP_OK) sanitize(temp, id_icon, 9);
-        if (httpd_query_key_value(buf, "tagline", temp, sizeof(temp)) == ESP_OK) sanitize(temp, id_tagline, 101);
-        if (httpd_query_key_value(buf, "rules", temp, sizeof(temp)) == ESP_OK) sanitize(temp, id_rules, 101);
-        if (httpd_query_key_value(buf, "footer", temp, sizeof(temp)) == ESP_OK) sanitize(temp, id_footer, 101);
+        if (httpd_query_key_value(buf, "name", temp, sizeof(temp)) == ESP_OK) { urldecode(temp, temp); sanitize(temp, id_name, 49); }
+        if (httpd_query_key_value(buf, "icon", temp, sizeof(temp)) == ESP_OK) { urldecode(temp, temp); sanitize(temp, id_icon, 9); }
+        if (httpd_query_key_value(buf, "tagline", temp, sizeof(temp)) == ESP_OK) { urldecode(temp, temp); sanitize(temp, id_tagline, 101); }
+        if (httpd_query_key_value(buf, "rules", temp, sizeof(temp)) == ESP_OK) { urldecode(temp, temp); sanitize(temp, id_rules, 101); }
+        if (httpd_query_key_value(buf, "footer", temp, sizeof(temp)) == ESP_OK) { urldecode(temp, temp); sanitize(temp, id_footer, 101); }
         bb_save_identity();
         httpd_resp_send(req, "identity saved", 14);
         return ESP_OK;

--- a/main/bulletin_api.h
+++ b/main/bulletin_api.h
@@ -7,6 +7,9 @@
 extern "C" {
 #endif
 
+// URL Decode function from main.c
+void urldecode(char *dst, const char *src);
+
 // Check if request has an admin token or if the hardware key is present
 bool bb_is_admin_request(httpd_req_t *req);
 

--- a/main/main.c
+++ b/main/main.c
@@ -581,7 +581,7 @@ static esp_err_t static_file_handler(httpd_req_t *req) {
 
 
 // Simple URL decode function
-static void urldecode(char *dst, const char *src) {
+void urldecode(char *dst, const char *src) {
     char a, b;
     while (*src) {
         if ((*src == '%') &&


### PR DESCRIPTION
This commit resolves an issue where special characters and spaces (such as `+`, `%2B`, `%E2%80%A2`) were corrupted when saving settings on the admin page. It achieves this by URL-decoding the retrieved form data before sanitizing and saving it to memory.

- Removed `static` keyword from `urldecode` function in `main/main.c`.
- Exported `void urldecode(char *dst, const char *src);` in `main/bulletin_api.h`.
- Applied `urldecode(temp, temp);` to `httpd_query_key_value` results in `admin_identity_set_handler` within `main/bulletin_api.c`.

---
*PR created automatically by Jules for task [5898307471627217769](https://jules.google.com/task/5898307471627217769) started by @LokiMetaSmith*