### PR TITLE
Fix SD card initialization timeout (0x107)

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -1591,7 +1591,6 @@ void init_sd_card(void) {
     gpio_set_pull_mode(PIN_NUM_CS, GPIO_PULLUP_ONLY);
 
     sdmmc_host_t host = SDSPI_HOST_DEFAULT();
-    host.max_freq_khz = SDMMC_FREQ_PROBING; // Use probing frequency for initialization
     spi_bus_config_t bus_cfg = {
         .mosi_io_num = PIN_NUM_MOSI,
         .miso_io_num = PIN_NUM_MISO,


### PR DESCRIPTION
Fixes the 0x107 SD card initialization timeout issue by allowing the driver to correctly ramp up the SPI bus frequency after probing.

---
*PR created automatically by Jules for task [9708832158042141540](https://jules.google.com/task/9708832158042141540) started by @LokiMetaSmith*