### PR TITLE
🛡️ Sentinel: [High] Fix HTTP Server Stack Overflow DoS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,9 @@
 **Vulnerability:** Null Pointer Dereference (DoS) and Path Traversal
 **Learning:** ESP-IDF HTTP handlers using `cJSON` must explicitly check that `cJSON_GetObjectItem(json, "key")` does not return NULL before attempting to access its properties like `->valuestring`. Failing to do so causes a hard crash when malformed payloads are received. Additionally, VFS operations in ESP-IDF require manual path traversal checks (e.g. `strstr(filename, "..")`).
 **Prevention:** Always check both the item and its specific value field for NULL, and manually validate inputs used in file system paths.
+
+## 2026-06-19 - Fix HTTP Server Stack Overflow DoS
+
+**Learning:** When using FreeRTOS, tasks are given a fixed stack size. Functions handling HTTP requests (such as `board_post_handler`) that declare large stack buffers (like `char buf[1024];`) can quickly exhaust the task stack, leading to a `LoadProhibited` Guru Meditation Error (Crash). This acts as a Denial of Service (DoS) vulnerability.
+
+**Action:** Increased the HTTP server task stack size (`config.stack_size = 8192;`) to provide a safer baseline for endpoints performing heavily recursive or stack-intensive operations like `cJSON` parsing and File I/O. Furthermore, migrated large string buffers in `bulletin_api.c` (e.g., `1024`, `512`, `256` bytes) and `bulletin_board.c` from the stack to the heap using `malloc()` and carefully implemented `free()` calls across all exit and error paths to prevent memory leaks.

--- a/main/bulletin_api.c
+++ b/main/bulletin_api.c
@@ -70,18 +70,27 @@ static esp_err_t board_messages_handler(httpd_req_t *req) {
 }
 
 static esp_err_t board_post_handler(httpd_req_t *req) {
-    char buf[1024];
     int ret, remaining = req->content_len;
-    if (remaining >= sizeof(buf)) {
+    if (remaining >= 1024) {
         httpd_resp_send_408(req);
         return ESP_FAIL;
     }
 
+    char *buf = (char *)malloc(1024);
+    if (!buf) {
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+
     ret = httpd_req_recv(req, buf, remaining);
-    if (ret <= 0) return ESP_FAIL;
+    if (ret <= 0) {
+        free(buf);
+        return ESP_FAIL;
+    }
     buf[ret] = '\0';
 
     cJSON *json = cJSON_Parse(buf);
+    free(buf);
     if (!json) {
         httpd_resp_send_500(req);
         return ESP_FAIL;
@@ -121,18 +130,27 @@ static esp_err_t board_post_handler(httpd_req_t *req) {
 }
 
 static esp_err_t admin_auth_handler(httpd_req_t *req) {
-    char buf[256];
     int ret, remaining = req->content_len;
-    if (remaining >= sizeof(buf)) {
+    if (remaining >= 256) {
         httpd_resp_send_408(req);
         return ESP_FAIL;
     }
 
+    char *buf = (char *)malloc(256);
+    if (!buf) {
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+
     ret = httpd_req_recv(req, buf, remaining);
-    if (ret <= 0) return ESP_FAIL;
+    if (ret <= 0) {
+        free(buf);
+        return ESP_FAIL;
+    }
     buf[ret] = '\0';
 
     cJSON *json = cJSON_Parse(buf);
+    free(buf);
     if (!json) { httpd_resp_send_500(req); return ESP_FAIL; }
 
     cJSON *j_key = cJSON_GetObjectItem(json, "key");
@@ -149,13 +167,17 @@ static esp_err_t admin_auth_handler(httpd_req_t *req) {
 
 bool bb_is_admin_request(httpd_req_t *req) {
     if (g_hardware_key_authenticated) return true;
-    char buf[512];
-    if (httpd_req_get_url_query_str(req, buf, sizeof(buf)) == ESP_OK) {
+    char *buf = (char *)malloc(512);
+    if (!buf) return false;
+
+    if (httpd_req_get_url_query_str(req, buf, 512) == ESP_OK) {
         char token[33];
         if (httpd_query_key_value(buf, "token", token, sizeof(token)) == ESP_OK) {
+            free(buf);
             return bb_is_token_valid(token);
         }
     }
+    free(buf);
     return false;
 }
 
@@ -176,8 +198,13 @@ static esp_err_t admin_identity_get_handler(httpd_req_t *req) {
 static esp_err_t admin_identity_set_handler(httpd_req_t *req) {
     if (!bb_is_admin_request(req)) { httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "forbidden"); return ESP_FAIL; }
     
-    char buf[512];
-    if (httpd_req_get_url_query_str(req, buf, sizeof(buf)) == ESP_OK) {
+    char *buf = (char *)malloc(512);
+    if (!buf) {
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+
+    if (httpd_req_get_url_query_str(req, buf, 512) == ESP_OK) {
         char temp[101];
         if (httpd_query_key_value(buf, "name", temp, sizeof(temp)) == ESP_OK) { urldecode(temp, temp); sanitize(temp, id_name, 49); }
         if (httpd_query_key_value(buf, "icon", temp, sizeof(temp)) == ESP_OK) { urldecode(temp, temp); sanitize(temp, id_icon, 9); }
@@ -185,9 +212,11 @@ static esp_err_t admin_identity_set_handler(httpd_req_t *req) {
         if (httpd_query_key_value(buf, "rules", temp, sizeof(temp)) == ESP_OK) { urldecode(temp, temp); sanitize(temp, id_rules, 101); }
         if (httpd_query_key_value(buf, "footer", temp, sizeof(temp)) == ESP_OK) { urldecode(temp, temp); sanitize(temp, id_footer, 101); }
         bb_save_identity();
+        free(buf);
         httpd_resp_send(req, "identity saved", 14);
         return ESP_OK;
     }
+    free(buf);
     httpd_resp_send_500(req);
     return ESP_FAIL;
 }
@@ -195,16 +224,23 @@ static esp_err_t admin_identity_set_handler(httpd_req_t *req) {
 static esp_err_t admin_setkey_handler(httpd_req_t *req) {
     if (!bb_is_admin_request(req)) { httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "forbidden"); return ESP_FAIL; }
     
-    char buf[128];
-    if (httpd_req_get_url_query_str(req, buf, sizeof(buf)) == ESP_OK) {
+    char *buf = (char *)malloc(128);
+    if (!buf) {
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+
+    if (httpd_req_get_url_query_str(req, buf, 128) == ESP_OK) {
         char temp[65];
         if (httpd_query_key_value(buf, "newkey", temp, sizeof(temp)) == ESP_OK) {
             strncpy(admin_key, temp, 64);
             bb_save_admin_key();
+            free(buf);
             httpd_resp_send(req, "key updated", 11);
             return ESP_OK;
         }
     }
+    free(buf);
     httpd_resp_send_500(req);
     return ESP_FAIL;
 }
@@ -219,16 +255,23 @@ static esp_err_t admin_clear_handler(httpd_req_t *req) {
 static esp_err_t admin_delete_post_handler(httpd_req_t *req) {
     if (!bb_is_admin_request(req)) { httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "forbidden"); return ESP_FAIL; }
     
-    char buf[128];
-    if (httpd_req_get_url_query_str(req, buf, sizeof(buf)) == ESP_OK) {
+    char *buf = (char *)malloc(128);
+    if (!buf) {
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+
+    if (httpd_req_get_url_query_str(req, buf, 128) == ESP_OK) {
         char temp[16];
         if (httpd_query_key_value(buf, "id", temp, sizeof(temp)) == ESP_OK) {
             uint16_t targetId = atoi(temp);
             bb_delete_message(targetId);
+            free(buf);
             httpd_resp_send(req, "deleted", 7);
             return ESP_OK;
         }
     }
+    free(buf);
     httpd_resp_send_500(req);
     return ESP_FAIL;
 }

--- a/main/bulletin_board.c
+++ b/main/bulletin_board.c
@@ -234,9 +234,12 @@ void bb_add_message(const char* author, const char* type, const char* text, int 
     msgsDirty = true;
     bb_save_messages();
     
-    char lora_msg[512];
-    snprintf(lora_msg, sizeof(lora_msg), "MSG|%s|%s|%s", author, type, text);
-    lora_wan_broadcast(lora_msg);
+    char *lora_msg = (char *)malloc(512);
+    if (lora_msg) {
+        snprintf(lora_msg, 512, "MSG|%s|%s|%s", author, type, text);
+        lora_wan_broadcast(lora_msg);
+        free(lora_msg);
+    }
 }
 
 void bb_delete_message(uint16_t targetId) {

--- a/main/main.c
+++ b/main/main.c
@@ -1059,6 +1059,7 @@ static httpd_handle_t start_webserver(void) {
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
     config.uri_match_fn = httpd_uri_match_wildcard;
     config.max_uri_handlers = 24;
+    config.stack_size = 8192;
 
     ESP_LOGI(TAG, "Starting server on port: '%d'", config.server_port);
     if (httpd_start(&server, &config) == ESP_OK) {


### PR DESCRIPTION
**What:**
- Increased the HTTP server task stack size in `main.c` from the default to `8192` bytes.
- Refactored large stack-allocated string buffers (ranging from 128 to 1024 bytes) in `main/bulletin_api.c` and `main/bulletin_board.c` to use heap allocation via `malloc()` and `free()`.
- Guarded `malloc` and `cJSON_Parse` failures appropriately, ensuring memory is freed across all return paths to prevent leaks.
- Added documentation for this vulnerability to `.jules/sentinel.md`.

**Why:**
The web server was vulnerable to a Denial of Service (DoS) attack. When a user posted a message (which parses JSON and performs file system operations), the large stack allocations (e.g., `char buf[1024]`) rapidly exhausted the FreeRTOS task stack, leading to a `LoadProhibited` Guru Meditation Error and device crash.

**Impact:**
The device will no longer crash due to stack exhaustion when handling HTTP requests, particularly those involving the Bulletin Board API.

**Security:**
Fixes a Denial of Service (DoS) vulnerability. Memory leaks have been mitigated by carefully checking all exit paths for proper cleanup.

---
*PR created automatically by Jules for task [5253369248460493921](https://jules.google.com/task/5253369248460493921) started by @LokiMetaSmith*