### PR TITLE
🎨 Palette: Add loading state and disabled styling to post button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-06-19 - [Form Accessibility]
 **Learning:** Found several input fields relying solely on placeholders or lacking 'for' attributes on labels, which hurts screen reader users and reduces click targets.
 **Action:** Always pair inputs with explicit <label for="..."> elements to improve both accessibility and usability.
+## 2024-11-20 - Adding immediate visual feedback for submit actions
+**Learning:** Vanilla JS frontends (like in `board.html`) often lack default form-submission loading states compared to component frameworks. Without immediate visual feedback (e.g., disabling the button, changing text to "POSTING..."), users may experience a perceived latency delay, especially when the backend process takes noticeable time, leading to potential duplicate submissions. Adding basic disabled styles (`opacity` & `cursor: not-allowed`) alongside JavaScript state toggles is a crucial low-hanging UX improvement for these raw setups.
+**Action:** When adding async interaction endpoints in vanilla JS templates, always include a manual disabled/loading state toggle wrapping the `fetch()` call to improve perceived responsiveness and prevent double-posting.

--- a/main/web_assets/board.html
+++ b/main/web_assets/board.html
@@ -195,6 +195,7 @@ body {
   align-self: flex-end;
 }
 .post-btn:hover { background: #a06b43; }
+.post-btn:disabled { opacity: 0.6; cursor: not-allowed; }
 
 /* ── Filter bar ── */
 .filter-bar {
@@ -588,16 +589,30 @@ async function doPost() {
   const t = document.getElementById('msgIn').value.trim();
   if (!t) return;
 
+  const btn = document.getElementById('postBtn');
+  if (btn) {
+    btn.disabled = true;
+    btn.textContent = 'POSTING...';
+  }
+
   localStorage.setItem('cn_name', n);
   document.getElementById('nameIn').value = n;
 
-  await fetch('/board/post', {
-    method: 'POST',
-    body: JSON.stringify({ author: n, type: currentType, text: t, expiry: currentExpiry })
-  });
+  try {
+    await fetch('/board/post', {
+      method: 'POST',
+      body: JSON.stringify({ author: n, type: currentType, text: t, expiry: currentExpiry })
+    });
 
-  document.getElementById('msgIn').value      = '';
-  document.getElementById('msgHint').textContent = '';
+    document.getElementById('msgIn').value      = '';
+    document.getElementById('msgHint').textContent = '';
+  } finally {
+    if (btn) {
+      btn.disabled = false;
+      btn.textContent = 'POST';
+    }
+  }
+
   load();
   loadSystemStatus();
 }


### PR DESCRIPTION
💡 **What**: Added immediate visual feedback to the Bulletin Board post button. While an asynchronous post request is pending, the button is temporarily disabled, visually grayed out with a 'not-allowed' cursor, and its text changes to "POSTING...".
🎯 **Why**: Because the E-Book Librarian UI is pure vanilla HTML/JS, it lacked default form-submission loading states. Without this immediate feedback, users experience perceived latency and may click the button multiple times, causing duplicate posts.
📸 **Before/After**: The button now visually reacts to clicks, whereas previously it stayed static during the fetch delay.
♿ **Accessibility**: Added a `:disabled` pseudo-class and sets the HTML `disabled` attribute to communicate the pending state to screen readers and prevent multiple accidental keyboard activations.

---
*PR created automatically by Jules for task [10879816582249732507](https://jules.google.com/task/10879816582249732507) started by @LokiMetaSmith*