### PR TITLE
🎨 Palette: Use custom color breathing in AP mode

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -220,6 +220,7 @@ typedef enum {
     LED_STATE_CONNECTED,
     LED_STATE_TRANSFER,
     LED_STATE_ERROR,
+    LED_STATE_SETUP, // New state for config mode
     LED_STATE_EJECT, // For eject button feedback
     LED_STATE_WAIT_CONFIRM,
 } led_state_t;
@@ -1908,6 +1909,21 @@ static void led_status_task(void *pvParameters) {
                 vTaskDelay(pdMS_TO_TICKS(35));
                 break;
 
+            case LED_STATE_SETUP: // Pulsing purple
+                if (increasing) {
+                    brightness += 2;
+                    if (brightness >= 100) increasing = false;
+                } else {
+                    brightness -= 2;
+                    if (brightness <= 0) increasing = true;
+                }
+                for (int i = 0; i < LED_STRIP_LED_NUMBERS; i++) {
+                    led_strip_set_pixel(g_led_strip, i, brightness, 0, brightness);
+                }
+                led_strip_refresh(g_led_strip);
+                vTaskDelay(pdMS_TO_TICKS(20));
+                break;
+
             case LED_STATE_CONNECTED: // Solid Green
                 for (int i = 0; i < LED_STRIP_LED_NUMBERS; i++) {
                     led_strip_set_pixel(g_led_strip, i, 0, 128, 0); // Green
@@ -2149,6 +2165,9 @@ void app_main(void) {
     // Initialize LED strip early so we can show status
     init_led_strip();
     xTaskCreate(led_status_task, "led_status_task", 2048, NULL, 5, NULL);
+
+    // Show setup (purple pulsing) while trying to initialize/connect
+    g_led_state = LED_STATE_SETUP;
 
     // Initialize BLE for configuration
     init_ble();

--- a/main/main.c
+++ b/main/main.c
@@ -220,7 +220,6 @@ typedef enum {
     LED_STATE_CONNECTED,
     LED_STATE_TRANSFER,
     LED_STATE_ERROR,
-    LED_STATE_SETUP, // New state for config mode
     LED_STATE_EJECT, // For eject button feedback
     LED_STATE_WAIT_CONFIRM,
 } led_state_t;
@@ -1909,21 +1908,6 @@ static void led_status_task(void *pvParameters) {
                 vTaskDelay(pdMS_TO_TICKS(35));
                 break;
 
-            case LED_STATE_SETUP: // Pulsing purple
-                if (increasing) {
-                    brightness += 2;
-                    if (brightness >= 100) increasing = false;
-                } else {
-                    brightness -= 2;
-                    if (brightness <= 0) increasing = true;
-                }
-                for (int i = 0; i < LED_STRIP_LED_NUMBERS; i++) {
-                    led_strip_set_pixel(g_led_strip, i, brightness, 0, brightness);
-                }
-                led_strip_refresh(g_led_strip);
-                vTaskDelay(pdMS_TO_TICKS(20));
-                break;
-
             case LED_STATE_CONNECTED: // Solid Green
                 for (int i = 0; i < LED_STRIP_LED_NUMBERS; i++) {
                     led_strip_set_pixel(g_led_strip, i, 0, 128, 0); // Green
@@ -2184,7 +2168,7 @@ void app_main(void) {
     } else {
         // Configuration mode
         ESP_LOGI(TAG, "Starting AP mode services...");
-        g_led_state = LED_STATE_SETUP; // Set LED to setup mode
+        g_led_state = LED_STATE_IDLE; // Use standard idle mode in AP mode
         start_dns_server();
         ESP_LOGI(TAG, "AP mode and Captive Portal services are running. Connect to the Wi-Fi AP to configure or browse.");
     }


### PR DESCRIPTION
Change the LED status logic so that when the device boots into standalone Access Point (AP) mode, it defaults to the standard `LED_STATE_IDLE` breathing effect using the user-configured custom color.

This removes the hardcoded fast-pulsing purple "Setup Mode" indication, allowing the device to look natural and cozy while operating offline.

---
*PR created automatically by Jules for task [6516373857293072713](https://jules.google.com/task/6516373857293072713) started by @LokiMetaSmith*