### PR TITLE
Fix file chooser not opening in captive portal WebViews

### DIFF
--- a/main/web_assets/index.html
+++ b/main/web_assets/index.html
@@ -37,7 +37,7 @@
                     <form @submit.prevent="uploadBook" style="display: flex; flex-wrap: wrap; gap: 10px; align-items: flex-end;">
                         <div>
                             <label style="display: block; font-size: 0.9em; margin-bottom: 5px;">File</label>
-                            <input type="file" ref="fileInput" accept=".epub,.mobi,.pdf,.txt,.html" required>
+                            <input type="file" ref="fileInput" required>
                         </div>
                         <div>
                             <label style="display: block; font-size: 0.9em; margin-bottom: 5px;">Title</label>


### PR DESCRIPTION
Fixes an issue where the file picker dialog was unresponsive or grayed out in captive portal WebViews by removing the restrictive `accept` attribute.

---
*PR created automatically by Jules for task [747395571943081305](https://jules.google.com/task/747395571943081305) started by @LokiMetaSmith*