### PR TITLE
fix: lower Wi-Fi auth threshold to support standard WPA2 networks

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -1691,7 +1691,7 @@ void init_wifi(void) {
         ESP_ERROR_CHECK(esp_event_handler_instance_register(WIFI_EVENT, ESP_EVENT_ANY_ID, &wifi_event_handler, NULL, NULL));
         ESP_ERROR_CHECK(esp_event_handler_instance_register(IP_EVENT, IP_EVENT_STA_GOT_IP, &wifi_event_handler, NULL, NULL));
 
-        wifi_config_t wifi_config = { .sta = { .threshold.authmode = WIFI_AUTH_WPA_WPA2_PSK } };
+        wifi_config_t wifi_config = { .sta = { .threshold.authmode = WIFI_AUTH_WPA_PSK } };
         strlcpy((char*)wifi_config.sta.ssid, ssid, sizeof(wifi_config.sta.ssid));
         strlcpy((char*)wifi_config.sta.password, password, sizeof(wifi_config.sta.password));
 


### PR DESCRIPTION
The previous Wi-Fi connection logic used `WIFI_AUTH_WPA_WPA2_PSK` for the connection threshold. Due to how ESP-IDF defines its authentication enums (`WIFI_AUTH_WPA2_PSK` is 3, while `WIFI_AUTH_WPA_WPA2_PSK` is 4), this configured the device to reject access points with a security mode of 3. Standard WPA2-only routers broadcast as mode 3, so the connection attempt would fail during the 4-way handshake (the log would show state `run -> init (0xf00)`). 

Lowering the threshold to `WIFI_AUTH_WPA_PSK` correctly permits connection to standard WPA2 routers, resolving the reported connection issues.

---
*PR created automatically by Jules for task [5861458775618580045](https://jules.google.com/task/5861458775618580045) started by @LokiMetaSmith*