### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in static file handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -8,3 +8,7 @@
 **Learning:** When using FreeRTOS, tasks are given a fixed stack size. Functions handling HTTP requests (such as `board_post_handler`) that declare large stack buffers (like `char buf[1024];`) can quickly exhaust the task stack, leading to a `LoadProhibited` Guru Meditation Error (Crash). This acts as a Denial of Service (DoS) vulnerability.
 
 **Action:** Increased the HTTP server task stack size (`config.stack_size = 8192;`) to provide a safer baseline for endpoints performing heavily recursive or stack-intensive operations like `cJSON` parsing and File I/O. Furthermore, migrated large string buffers in `bulletin_api.c` (e.g., `1024`, `512`, `256` bytes) and `bulletin_board.c` from the stack to the heap using `malloc()` and carefully implemented `free()` calls across all exit and error paths to prevent memory leaks.
+## 2026-06-20 - [Path Traversal in static file handler]
+**Vulnerability:** Unauthenticated path traversal in static_file_handler allowing arbitrary file read.
+**Learning:** The ESP-IDF VFS does not automatically sanitize directory traversal sequences like '..', requiring manual explicit checks.
+**Prevention:** Always sanitize or reject URIs containing '..' before appending them to base paths in custom VFS HTTP handlers.

--- a/main/main.c
+++ b/main/main.c
@@ -500,6 +500,13 @@ static esp_err_t save_credentials_post_handler(httpd_req_t *req) {
 // --- WEB SERVER HANDLERS (MAIN APP) ---
 static esp_err_t static_file_handler(httpd_req_t *req) {
 
+    // Prevent path traversal
+    if (strstr(req->uri, "..") != NULL) {
+        ESP_LOGE(TAG, "Path traversal attempt detected: %s", req->uri);
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid URI");
+        return ESP_FAIL;
+    }
+
     // If we're hitting /generate_204 or other known captive portal probe endpoints, redirect them to root
     if (strstr(req->uri, "generate_204") != NULL || strstr(req->uri, "hotspot-detect") != NULL) {
         httpd_resp_set_status(req, "302 Temporary Redirect");


### PR DESCRIPTION
**🚨 Severity:** CRITICAL
**💡 Vulnerability:** Unauthenticated path traversal in `static_file_handler`. The `req->uri` was passed directly into `snprintf` to construct the file path without sanitizing or rejecting sequences like `..`. Because the ESP-IDF VFS does not inherently sanitize paths, an attacker could request `GET /../../sdcard/secret.txt` to read arbitrary files from the filesystem.
**🎯 Impact:** Allows unauthenticated reading of arbitrary files on the device filesystem, potentially exposing configuration, sensitive keys, or other user data.
**🔧 Fix:** Added a manual path traversal check (`strstr(req->uri, "..")`) at the beginning of `static_file_handler`. If a traversal sequence is detected, it logs a warning and returns `HTTPD_400_BAD_REQUEST` to fail securely.
**✅ Verification:** To verify, perform an HTTP GET request to the device with a path traversal attempt like `curl "http://<ip>/../../"`. It should return a `400 Bad Request` instead of redirecting or returning arbitrary file content. Build syntax was successfully verified via script.

---
*PR created automatically by Jules for task [9831634034902260627](https://jules.google.com/task/9831634034902260627) started by @LokiMetaSmith*