### PR TITLE
⚡ Bolt: Cache expensive FAT filesystem info on status endpoint

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-20 - [Avoid polling FAT filesystem metadata on ESP-IDF]
+**Learning:** Polling `esp_vfs_fat_info` recursively traverses the FAT cluster chain to calculate free space. When called every second by frontend UI polling (like `/status`), this causes significant SPI bus latency and locks the VFS, creating a bottleneck that starves other FreeRTOS tasks (like network serving or HTTP handlers).
+**Action:** When implementing status endpoints in ESP-IDF that report filesystem metrics, ALWAYS cache the result of `esp_vfs_fat_info` using `xTaskGetTickCount()` (e.g. for 10 seconds), only bypassing the cache when an active file transfer is known to be modifying the disk.

--- a/main/main.c
+++ b/main/main.c
@@ -834,6 +834,13 @@ static esp_err_t download_handler(httpd_req_t *req) {
     return ESP_OK;
 }
 
+
+static uint32_t cached_sd_total_mb = 0;
+static uint32_t cached_sd_used_mb = 0;
+static TickType_t last_sd_info_ticks = 0;
+static bool sd_info_cached = false;
+#define SD_INFO_CACHE_DURATION_MS 10000
+
 static esp_err_t status_handler(httpd_req_t *req) {
     httpd_resp_set_type(req, "application/json");
     cJSON *root = cJSON_CreateObject();
@@ -849,14 +856,21 @@ static esp_err_t status_handler(httpd_req_t *req) {
 
 
     if (g_sd_card_initialized) {
-        uint64_t out_total_bytes, out_free_bytes;
-        if (esp_vfs_fat_info(MOUNT_POINT_SD, &out_total_bytes, &out_free_bytes) == ESP_OK) {
-            uint32_t total_mb = out_total_bytes / (1024 * 1024);
-            uint32_t free_mb = out_free_bytes / (1024 * 1024);
-            uint32_t used_mb = total_mb > free_mb ? total_mb - free_mb : 0;
+        TickType_t now_ticks = xTaskGetTickCount();
+        if (!sd_info_cached || (now_ticks - last_sd_info_ticks) > pdMS_TO_TICKS(SD_INFO_CACHE_DURATION_MS) || g_transfer_progress.active) {
+            uint64_t out_total_bytes, out_free_bytes;
+            if (esp_vfs_fat_info(MOUNT_POINT_SD, &out_total_bytes, &out_free_bytes) == ESP_OK) {
+                cached_sd_total_mb = out_total_bytes / (1024 * 1024);
+                uint32_t free_mb = out_free_bytes / (1024 * 1024);
+                cached_sd_used_mb = cached_sd_total_mb > free_mb ? cached_sd_total_mb - free_mb : 0;
+                last_sd_info_ticks = now_ticks;
+                sd_info_cached = true;
+            }
+        }
 
-            cJSON_AddNumberToObject(root, "sd_total_mb", total_mb);
-            cJSON_AddNumberToObject(root, "sd_used_mb", used_mb);
+        if (sd_info_cached) {
+            cJSON_AddNumberToObject(root, "sd_total_mb", cached_sd_total_mb);
+            cJSON_AddNumberToObject(root, "sd_used_mb", cached_sd_used_mb);
         }
     }
 


### PR DESCRIPTION
**💡 What:** Implemented a 10-second cache for `esp_vfs_fat_info` in `main/main.c`, driven by `xTaskGetTickCount()`. The cache is completely bypassed/invalidated immediately if a file transfer is actively modifying the disk.

**🎯 Why:** The `/status` HTTP endpoint is polled every second by the UI frontend to monitor system state. Unfortunately, `esp_vfs_fat_info` recursively parses the FAT cluster chain to accurately report used and free megabytes. Calling this every 1000ms locks up the VFS abstraction layer and occupies the shared SPI bus, creating a major performance bottleneck that starves other FreeRTOS tasks.

**📊 Impact:** Eliminates 90% of recursive FAT traversals during idle HTTP polling. Reduces SPI contention, decreasing latency for page loads and other simultaneous file operations.

**🔬 Measurement:** Test the UI responsiveness by continuously polling `/status` using an external script while simultaneously fetching large static assets like `epub.min.js`. The network TTFB (Time To First Byte) for assets will decrease drastically.

---
*PR created automatically by Jules for task [6772951769796819868](https://jules.google.com/task/6772951769796819868) started by @LokiMetaSmith*