### PR TITLE
🎨 Palette: Add form labels for accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-11-20 - Adding immediate visual feedback for submit actions
 **Learning:** Vanilla JS frontends (like in `board.html`) often lack default form-submission loading states compared to component frameworks. Without immediate visual feedback (e.g., disabling the button, changing text to "POSTING..."), users may experience a perceived latency delay, especially when the backend process takes noticeable time, leading to potential duplicate submissions. Adding basic disabled styles (`opacity` & `cursor: not-allowed`) alongside JavaScript state toggles is a crucial low-hanging UX improvement for these raw setups.
 **Action:** When adding async interaction endpoints in vanilla JS templates, always include a manual disabled/loading state toggle wrapping the `fetch()` call to improve perceived responsiveness and prevent double-posting.
+## 2024-06-21 - [Form Accessibility]
+**Learning:** Vanilla HTML forms in this project's UI (like `index.html`) sometimes lack explicit programmatic associations between labels and input fields. Using only placeholders or unlinked labels reduces the click target area and degrades the experience for screen reader users.
+**Action:** When working on UI forms, ensure all input elements (`<input>`) have explicit `id` attributes that are strictly matched with `for` attributes on their corresponding `<label>` elements.

--- a/main/web_assets/index.html
+++ b/main/web_assets/index.html
@@ -36,16 +36,16 @@
                     <h3 style="margin-top: 0;">Upload Book</h3>
                     <form @submit.prevent="uploadBook" style="display: flex; flex-wrap: wrap; gap: 10px; align-items: flex-end;">
                         <div>
-                            <label style="display: block; font-size: 0.9em; margin-bottom: 5px;">File</label>
-                            <input type="file" ref="fileInput" required>
+                            <label for="uploadFile" style="display: block; font-size: 0.9em; margin-bottom: 5px;">File</label>
+                            <input type="file" id="uploadFile" ref="fileInput" required>
                         </div>
                         <div>
-                            <label style="display: block; font-size: 0.9em; margin-bottom: 5px;">Title</label>
-                            <input type="text" v-model="uploadTitle" placeholder="Title" required>
+                            <label for="uploadTitle" style="display: block; font-size: 0.9em; margin-bottom: 5px;">Title</label>
+                            <input type="text" id="uploadTitle" v-model="uploadTitle" placeholder="Title" required>
                         </div>
                         <div>
-                            <label style="display: block; font-size: 0.9em; margin-bottom: 5px;">Author</label>
-                            <input type="text" v-model="uploadAuthor" placeholder="Author" required>
+                            <label for="uploadAuthor" style="display: block; font-size: 0.9em; margin-bottom: 5px;">Author</label>
+                            <input type="text" id="uploadAuthor" v-model="uploadAuthor" placeholder="Author" required>
                         </div>
                         <button type="submit" :disabled="isUploading">
                             {{ isUploading ? 'Uploading...' : 'Upload' }}


### PR DESCRIPTION
**💡 What:** 
Added explicit `id` attributes to the input fields (File, Title, Author) in the 'Upload Book' section on `index.html` and linked them to their corresponding `<label>` elements using `for` attributes. Updated `.Jules/palette.md` with learnings about ensuring this pattern in vanilla UI files.

**🎯 Why:** 
The upload form inputs were previously relying solely on structural proximity for their labels. Without explicit `for`/`id` linking, the labels could not be clicked to focus the inputs (reducing user click targets), and assistive technologies (like screen readers) might struggle to announce the fields accurately to users.

**📸 Before/After:** 
No visual change in layout. Click targets for inputs are now expanded to include the label text. (Verified visually via Playwright).

**♿ Accessibility:**
- Form controls now have explicit programmatic associations with their text labels.
- Follows WCAG 2.1 SC 1.3.1 (Info and Relationships) and 3.3.2 (Labels or Instructions) standards.

---
*PR created automatically by Jules for task [17458498413035889158](https://jules.google.com/task/17458498413035889158) started by @LokiMetaSmith*