### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent query string truncation DoS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** Unauthenticated path traversal in static_file_handler allowing arbitrary file read.
 **Learning:** The ESP-IDF VFS does not automatically sanitize directory traversal sequences like '..', requiring manual explicit checks.
 **Prevention:** Always sanitize or reject URIs containing '..' before appending them to base paths in custom VFS HTTP handlers.
+
+## 2025-02-14 - Prevent query string truncation DoS
+**Vulnerability:** Fixed-size buffers for query string extraction (Truncation Risk / DoS)
+**Learning:** ESP-IDF's `httpd_req_get_url_query_str` relies on the buffer size passed as an argument. If a fixed-size buffer is used (e.g., `char buf[512]`) and the client sends a query string longer than this buffer, the function returns `ESP_ERR_HTTPD_RESULT_TRUNC`. If this error isn't explicitly handled, or if the buffer truncates maliciously constructed input, it can bypass security checks, truncate data unexpectedly, or silently fail.
+**Prevention:** Always dynamically size the buffer for `httpd_req_get_url_query_str` using `size_t query_len = httpd_req_get_url_query_len(req);` and allocate memory as `malloc(query_len + 1)`. Ensure `free()` is called on all code paths.

--- a/main/bulletin_api.c
+++ b/main/bulletin_api.c
@@ -167,10 +167,14 @@ static esp_err_t admin_auth_handler(httpd_req_t *req) {
 
 bool bb_is_admin_request(httpd_req_t *req) {
     if (g_hardware_key_authenticated) return true;
-    char *buf = (char *)malloc(512);
+
+    size_t query_len = httpd_req_get_url_query_len(req);
+    if (query_len == 0) return false;
+
+    char *buf = (char *)malloc(query_len + 1);
     if (!buf) return false;
 
-    if (httpd_req_get_url_query_str(req, buf, 512) == ESP_OK) {
+    if (httpd_req_get_url_query_str(req, buf, query_len + 1) == ESP_OK) {
         char token[33];
         if (httpd_query_key_value(buf, "token", token, sizeof(token)) == ESP_OK) {
             free(buf);
@@ -198,13 +202,19 @@ static esp_err_t admin_identity_get_handler(httpd_req_t *req) {
 static esp_err_t admin_identity_set_handler(httpd_req_t *req) {
     if (!bb_is_admin_request(req)) { httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "forbidden"); return ESP_FAIL; }
     
-    char *buf = (char *)malloc(512);
+    size_t query_len = httpd_req_get_url_query_len(req);
+    if (query_len == 0) {
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+
+    char *buf = (char *)malloc(query_len + 1);
     if (!buf) {
         httpd_resp_send_500(req);
         return ESP_FAIL;
     }
 
-    if (httpd_req_get_url_query_str(req, buf, 512) == ESP_OK) {
+    if (httpd_req_get_url_query_str(req, buf, query_len + 1) == ESP_OK) {
         char temp[101];
         if (httpd_query_key_value(buf, "name", temp, sizeof(temp)) == ESP_OK) { urldecode(temp, temp); sanitize(temp, id_name, 49); }
         if (httpd_query_key_value(buf, "icon", temp, sizeof(temp)) == ESP_OK) { urldecode(temp, temp); sanitize(temp, id_icon, 9); }
@@ -224,13 +234,19 @@ static esp_err_t admin_identity_set_handler(httpd_req_t *req) {
 static esp_err_t admin_setkey_handler(httpd_req_t *req) {
     if (!bb_is_admin_request(req)) { httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "forbidden"); return ESP_FAIL; }
     
-    char *buf = (char *)malloc(128);
+    size_t query_len = httpd_req_get_url_query_len(req);
+    if (query_len == 0) {
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+
+    char *buf = (char *)malloc(query_len + 1);
     if (!buf) {
         httpd_resp_send_500(req);
         return ESP_FAIL;
     }
 
-    if (httpd_req_get_url_query_str(req, buf, 128) == ESP_OK) {
+    if (httpd_req_get_url_query_str(req, buf, query_len + 1) == ESP_OK) {
         char temp[65];
         if (httpd_query_key_value(buf, "newkey", temp, sizeof(temp)) == ESP_OK) {
             strncpy(admin_key, temp, 64);
@@ -255,13 +271,19 @@ static esp_err_t admin_clear_handler(httpd_req_t *req) {
 static esp_err_t admin_delete_post_handler(httpd_req_t *req) {
     if (!bb_is_admin_request(req)) { httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "forbidden"); return ESP_FAIL; }
     
-    char *buf = (char *)malloc(128);
+    size_t query_len = httpd_req_get_url_query_len(req);
+    if (query_len == 0) {
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+
+    char *buf = (char *)malloc(query_len + 1);
     if (!buf) {
         httpd_resp_send_500(req);
         return ESP_FAIL;
     }
 
-    if (httpd_req_get_url_query_str(req, buf, 128) == ESP_OK) {
+    if (httpd_req_get_url_query_str(req, buf, query_len + 1) == ESP_OK) {
         char temp[16];
         if (httpd_query_key_value(buf, "id", temp, sizeof(temp)) == ESP_OK) {
             uint16_t targetId = atoi(temp);

--- a/main/main.c
+++ b/main/main.c
@@ -648,16 +648,22 @@ static esp_err_t upload_handler(httpd_req_t *req) {
     // or send the file directly in a POST, with title/author in URL query parameters!
     // That avoids memory-intensive multipart parsing on the ESP32.
 
-    char buf[512];
     char title[100] = "Unknown Title";
     char author[100] = "Unknown Author";
     char filename[100] = "upload.epub";
 
-    if (httpd_req_get_url_query_str(req, buf, sizeof(buf)) == ESP_OK) {
-        char param[100];
-        if (httpd_query_key_value(buf, "title", param, sizeof(param)) == ESP_OK) urldecode(title, param);
-        if (httpd_query_key_value(buf, "author", param, sizeof(param)) == ESP_OK) urldecode(author, param);
-        if (httpd_query_key_value(buf, "filename", param, sizeof(param)) == ESP_OK) urldecode(filename, param);
+    size_t query_len = httpd_req_get_url_query_len(req);
+    if (query_len > 0) {
+        char *buf = malloc(query_len + 1);
+        if (buf) {
+            if (httpd_req_get_url_query_str(req, buf, query_len + 1) == ESP_OK) {
+                char param[100];
+                if (httpd_query_key_value(buf, "title", param, sizeof(param)) == ESP_OK) urldecode(title, param);
+                if (httpd_query_key_value(buf, "author", param, sizeof(param)) == ESP_OK) urldecode(author, param);
+                if (httpd_query_key_value(buf, "filename", param, sizeof(param)) == ESP_OK) urldecode(filename, param);
+            }
+            free(buf);
+        }
     }
 
     // Check for directory traversal
@@ -750,8 +756,20 @@ static esp_err_t upload_handler(httpd_req_t *req) {
 }
 
 static esp_err_t download_handler(httpd_req_t *req) {
-    char buf[512];
-    if (httpd_req_get_url_query_str(req, buf, sizeof(buf)) != ESP_OK) {
+    size_t query_len = httpd_req_get_url_query_len(req);
+    if (query_len == 0) {
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Bad Request");
+        return ESP_FAIL;
+    }
+
+    char *buf = malloc(query_len + 1);
+    if (!buf) {
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+
+    if (httpd_req_get_url_query_str(req, buf, query_len + 1) != ESP_OK) {
+        free(buf);
         httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Bad Request");
         return ESP_FAIL;
     }
@@ -761,9 +779,11 @@ static esp_err_t download_handler(httpd_req_t *req) {
 
     if (httpd_query_key_value(buf, "file", file_param, sizeof(file_param)) != ESP_OK ||
         httpd_query_key_value(buf, "source", source_param, sizeof(source_param)) != ESP_OK) {
+        free(buf);
         httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Bad Request");
         return ESP_FAIL;
     }
+    free(buf);
 
     char decoded_file_param[128];
     urldecode(decoded_file_param, file_param);
@@ -894,17 +914,31 @@ static esp_err_t status_handler(httpd_req_t *req) {
 }
 
 static esp_err_t list_files_handler(httpd_req_t *req) {
-    char buf[128];
-    if (httpd_req_get_url_query_str(req, buf, sizeof(buf)) != ESP_OK) {
+    size_t query_len = httpd_req_get_url_query_len(req);
+    if (query_len == 0) {
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Bad Request");
+        return ESP_FAIL;
+    }
+
+    char *buf = malloc(query_len + 1);
+    if (!buf) {
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+
+    if (httpd_req_get_url_query_str(req, buf, query_len + 1) != ESP_OK) {
+        free(buf);
         httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Bad Request");
         return ESP_FAIL;
     }
 
     char param[32];
     if (httpd_query_key_value(buf, "type", param, sizeof(param)) != ESP_OK) {
+        free(buf);
         httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Bad Request");
         return ESP_FAIL;
     }
+    free(buf);
 
     const char *mount_path = (strcmp(param, "sd") == 0) ? MOUNT_POINT_SD : MOUNT_POINT_USB;
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Fixed-size buffers were used to parse URL query parameters via `httpd_req_get_url_query_str`. If a query string exceeded the buffer size, it would cause an `ESP_ERR_HTTPD_RESULT_TRUNC` error, which could potentially be used to bypass parameter validation, truncate inputs unexpectedly, or cause Denial of Service by crashing unhandled edge cases.
🎯 Impact: Could lead to subtle bugs or security bypasses if maliciously long URLs were provided to administrative endpoints.
🔧 Fix: Updated `bb_is_admin_request`, `admin_identity_set_handler`, `admin_setkey_handler`, `admin_delete_post_handler`, `upload_handler`, `download_handler`, and `list_files_handler` to dynamically allocate the buffer based on the exact size returned by `httpd_req_get_url_query_len(req)`.
✅ Verification: Code review confirms memory is safely allocated and fully freed on all execution paths. A journal entry was added to `.jules/sentinel.md` documenting the risk and prevention pattern.

---
*PR created automatically by Jules for task [16263935643386224192](https://jules.google.com/task/16263935643386224192) started by @LokiMetaSmith*