### PR TITLE
🎨 Palette: Add explicit form labels for accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-06-21 - [Form Accessibility]
 **Learning:** Vanilla HTML forms in this project's UI (like `index.html`) sometimes lack explicit programmatic associations between labels and input fields. Using only placeholders or unlinked labels reduces the click target area and degrades the experience for screen reader users.
 **Action:** When working on UI forms, ensure all input elements (`<input>`) have explicit `id` attributes that are strictly matched with `for` attributes on their corresponding `<label>` elements.
+## 2026-06-22 - Explicit Form Labels for Accessibility
+**Learning:** Found an accessibility issue pattern where inputs used only `placeholder` and `aria-label` attributes instead of explicit, visible `<label>` tags (e.g., in `setup.html` and the `admin.html` password gate). While `aria-label` provides screen reader context, relying solely on placeholder text is poor UX because the context disappears as soon as the user starts typing, which can be disorienting and fails to meet WCAG success criteria for visible labels.
+**Action:** Always pair inputs with visible, explicit `<label>` tags using the `for` and `id` attributes to ensure both visual persistence and screen reader compatibility.

--- a/main/web_assets/admin.html
+++ b/main/web_assets/admin.html
@@ -58,6 +58,11 @@ body {
   outline: none;
   margin-bottom: 10px;
 }
+#gate label {
+  font-size: 10px; letter-spacing: 1px;
+  text-transform: uppercase; color: var(--ink-muted);
+  display: block; margin-bottom: 5px;
+}
 #gate input:focus { border-color: var(--accent-dark); }
 #gate button {
   width: 100%;
@@ -202,8 +207,8 @@ textarea.restore-area:focus { border-color: var(--accent-dark); }
 <!-- Password gate -->
 <div id="gate">
   <h2>Admin Access</h2>
-  <input type="password" id="keyIn" aria-label="Admin Access Key" placeholder="Enter admin key"
-         autocomplete="off">
+  <label for="keyIn">Admin Access Key</label>
+  <input type="password" id="keyIn" autocomplete="off">
   <button onclick="tryLogin()">Unlock 🔑</button>
   <div class="error" id="gateErr"></div>
 </div>

--- a/main/web_assets/setup.html
+++ b/main/web_assets/setup.html
@@ -22,8 +22,14 @@
         <h1>Wi-Fi Setup</h1>
         <p>Connect your E-Book Librarian to your local Wi-Fi network.</p>
         <form action="/save-credentials" method="POST">
-            <input type="text" id="ssid" name="ssid" aria-label="Wi-Fi Network Name (SSID)" placeholder="Wi-Fi Network Name (SSID)" required>
-            <input type="password" id="password" name="password" aria-label="Password" placeholder="Password">
+            <div style="margin-bottom: 15px;">
+                <label for="ssid" style="display: block; text-align: left; margin-bottom: 5px; font-weight: bold; color: #555;">Wi-Fi Network Name (SSID)</label>
+                <input type="text" id="ssid" name="ssid" required style="margin-bottom: 0;">
+            </div>
+            <div style="margin-bottom: 20px;">
+                <label for="password" style="display: block; text-align: left; margin-bottom: 5px; font-weight: bold; color: #555;">Password</label>
+                <input type="password" id="password" name="password" style="margin-bottom: 0;">
+            </div>
             <button type="submit">Connect</button>
         </form>
         <div id="status"></div>


### PR DESCRIPTION
### 💡 What
Replaced placeholder and `aria-label` only form fields with explicit, visible `<label>` tags linked via `for` and `id` in `setup.html` and `admin.html`. Added basic layout styling to ensure the newly added labels blend in natively with the rest of the existing UI. 

### 🎯 Why
Placeholder text disappears as soon as users begin typing, causing them to lose context if they look away. For screen readers, while `aria-label` provides a hidden label, WCAG guidelines recommend visible textual labels. Explicit `<label for="...">` tags also increase the click target size since clicking the text focuses the input.

### 📸 Before/After
*(See attached screenshots and videos from playwright verification).*
**Before:** Inputs in the setup page and the admin gate solely relied on placeholders inside the input boxes.
**After:** Bold, distinct labels sit directly above their respective inputs, making form context permanent.

### ♿ Accessibility
This change provides true programmatic association between the visible labels and the input fields. This ensures screen readers announce the form inputs naturally and consistently while making it easier for sighted users to track what information goes into which field even after data has been entered.

---
*PR created automatically by Jules for task [15010781894085425783](https://jules.google.com/task/15010781894085425783) started by @LokiMetaSmith*