### PR TITLE
⚡ Bolt: [performance improvement] Start loraTransmitTask

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2024-06-21 - [Async Background Tasks]
 **Learning:** In ESP-IDF, synchronous actions that write to FAT filesystems (e.g. `esp_vfs_fat_sdmmc_...`) and transmit via LoRaWAN block the HTTP handler thread, delaying web responses. Using FreeRTOS Tasks with message Queues to offload long-running operations significantly improves the perceived performance of the web server.
 **Action:** Use `xQueueCreate` and `xTaskCreatePinnedToCore` to offload blocking tasks to a background thread.
+## 2024-05-19 - Started LoRa Transmit Task
+ **Learning:** Long-running hardware operations, such as LoRaWAN transmissions, need to be decoupled from HTTP request handlers using dedicated FreeRTOS background tasks (e.g., `loraTransmitTask`) pinned to Core 1 to prevent blocking the web server. Ensure these tasks are actually started via `xTaskCreatePinnedToCore` during initialization.
+ **Action:** Added `xTaskCreatePinnedToCore` for `loraTransmitTask` in `main/lorawan.cpp` to correctly start the background LoRa transmission queue processing.

--- a/main/lorawan.cpp
+++ b/main/lorawan.cpp
@@ -158,6 +158,17 @@ void lora_wan_init(void) {
             1
         );
 
+        // Start transmit/heartbeat task
+        xTaskCreatePinnedToCore(
+            loraTransmitTask,
+            "LoRaTransmit",
+            4096,
+            NULL,
+            5,
+            NULL,
+            1
+        );
+
     } else {
         ESP_LOGW(TAG, "SX1262 init failed (soft fail), code %d", state);
         lora_initialized = false;


### PR DESCRIPTION
What: Added `xTaskCreatePinnedToCore` to initialize `loraTransmitTask` in `lora_wan_init`.
Why: The task was implemented but never started, causing LoRa broadcasts to fail to execute in the background as specified by the `PERFORMANCE_ROADMAP.md`.
Impact: LoRaWAN broadcasts and heartbeats will now be correctly processed in the background on Core 1 without blocking the HTTP web server threads.
Measurement: Background processing verified by code logic completion.

---
*PR created automatically by Jules for task [13262557877294723829](https://jules.google.com/task/13262557877294723829) started by @LokiMetaSmith*