### PR TITLE
feat: Audio Radio Synchronized Playback

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 # List of source files for this component.
-set(COMPONENT_SRCS "main.c" "dns_server.c" "lorawan.cpp" "bulletin_board.c" "bulletin_api.c")
+set(COMPONENT_SRCS "main.c" "dns_server.c" "lorawan.cpp" "bulletin_board.c" "bulletin_api.c" "audio_api.c")
 
 # List of directories to add to the include path.
 set(COMPONENT_ADD_INCLUDEDIRS ".")

--- a/main/audio_api.c
+++ b/main/audio_api.c
@@ -1,0 +1,270 @@
+#include "audio_api.h"
+#include <esp_log.h>
+#include <esp_timer.h>
+#include <cJSON.h>
+#include <string.h>
+#include "bulletin_api.h"
+
+static const char *TAG = "AUDIO_API";
+
+#define MAX_QUEUE_SIZE 50
+#define MAX_FILENAME_LEN 128
+
+typedef struct {
+    char filename[MAX_FILENAME_LEN];
+} audio_track_t;
+
+static audio_track_t audio_queue[MAX_QUEUE_SIZE];
+static int queue_count = 0;
+
+static char current_track[MAX_FILENAME_LEN] = "";
+static bool is_playing = false;
+static int64_t track_start_time_us = 0; // The timestamp when play started or resumed
+static float track_position_sec = 0.0;   // The position when paused
+
+static void send_json_response(httpd_req_t *req, cJSON *root) {
+    char *json_str = cJSON_PrintUnformatted(root);
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_send(req, json_str, strlen(json_str));
+    free(json_str);
+    cJSON_Delete(root);
+}
+
+static esp_err_t audio_current_handler(httpd_req_t *req) {
+    cJSON *root = cJSON_CreateObject();
+
+    if (strlen(current_track) > 0) {
+        cJSON_AddStringToObject(root, "filename", current_track);
+        cJSON_AddBoolToObject(root, "playing", is_playing);
+
+        float current_pos = track_position_sec;
+        if (is_playing) {
+            int64_t now = esp_timer_get_time();
+            current_pos += (float)(now - track_start_time_us) / 1000000.0f;
+        }
+        cJSON_AddNumberToObject(root, "position", current_pos);
+    } else {
+        cJSON_AddNullToObject(root, "filename");
+        cJSON_AddBoolToObject(root, "playing", false);
+        cJSON_AddNumberToObject(root, "position", 0.0);
+    }
+
+    send_json_response(req, root);
+    return ESP_OK;
+}
+
+static esp_err_t audio_queue_get_handler(httpd_req_t *req) {
+    cJSON *root = cJSON_CreateArray();
+    for (int i = 0; i < queue_count; i++) {
+        cJSON_AddItemToArray(root, cJSON_CreateString(audio_queue[i].filename));
+    }
+    send_json_response(req, root);
+    return ESP_OK;
+}
+
+static esp_err_t audio_queue_post_handler(httpd_req_t *req) {
+    char buf[256];
+    int ret, remaining = req->content_len;
+
+    if (remaining >= sizeof(buf)) {
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Body too large");
+        return ESP_FAIL;
+    }
+
+    ret = httpd_req_recv(req, buf, remaining);
+    if (ret <= 0) {
+        if (ret == HTTPD_SOCK_ERR_TIMEOUT) {
+            httpd_resp_send_408(req);
+        }
+        return ESP_FAIL;
+    }
+    buf[ret] = '\0';
+
+    cJSON *json = cJSON_Parse(buf);
+    if (!json) {
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+
+    cJSON *filename_item = cJSON_GetObjectItem(json, "filename");
+    if (!filename_item || !cJSON_IsString(filename_item)) {
+        cJSON_Delete(json);
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Missing filename");
+        return ESP_FAIL;
+    }
+
+    const char* filename = filename_item->valuestring;
+
+    if (queue_count < MAX_QUEUE_SIZE) {
+        strncpy(audio_queue[queue_count].filename, filename, MAX_FILENAME_LEN - 1);
+        audio_queue[queue_count].filename[MAX_FILENAME_LEN - 1] = '\0';
+        queue_count++;
+
+        // If nothing is playing, automatically start the added track
+        if (strlen(current_track) == 0) {
+            strncpy(current_track, audio_queue[0].filename, MAX_FILENAME_LEN - 1);
+            current_track[MAX_FILENAME_LEN - 1] = '\0';
+
+            // Remove from queue
+            for (int i = 0; i < queue_count - 1; i++) {
+                strncpy(audio_queue[i].filename, audio_queue[i+1].filename, MAX_FILENAME_LEN);
+            }
+            queue_count--;
+
+            is_playing = true;
+            track_position_sec = 0.0;
+            track_start_time_us = esp_timer_get_time();
+        }
+    } else {
+        cJSON_Delete(json);
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Queue is full");
+        return ESP_FAIL;
+    }
+
+    cJSON_Delete(json);
+    httpd_resp_send(req, "{\"success\":true}", 16);
+    return ESP_OK;
+}
+
+static esp_err_t audio_queue_delete_handler(httpd_req_t *req) {
+    if (!bb_is_admin_request(req)) {
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Forbidden");
+        return ESP_FAIL;
+    }
+
+    char buf[256];
+    int ret, remaining = req->content_len;
+
+    if (remaining >= sizeof(buf)) {
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Body too large");
+        return ESP_FAIL;
+    }
+
+    ret = httpd_req_recv(req, buf, remaining);
+    if (ret <= 0) {
+        if (ret == HTTPD_SOCK_ERR_TIMEOUT) {
+            httpd_resp_send_408(req);
+        }
+        return ESP_FAIL;
+    }
+    buf[ret] = '\0';
+
+    cJSON *json = cJSON_Parse(buf);
+    if (!json) {
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+
+    cJSON *index_item = cJSON_GetObjectItem(json, "index");
+    if (!index_item || !cJSON_IsNumber(index_item)) {
+        cJSON_Delete(json);
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Missing index");
+        return ESP_FAIL;
+    }
+
+    int index = index_item->valueint;
+    if (index >= 0 && index < queue_count) {
+        for (int i = index; i < queue_count - 1; i++) {
+            strncpy(audio_queue[i].filename, audio_queue[i+1].filename, MAX_FILENAME_LEN);
+        }
+        queue_count--;
+    }
+
+    cJSON_Delete(json);
+    httpd_resp_send(req, "{\"success\":true}", 16);
+    return ESP_OK;
+}
+
+static esp_err_t audio_state_post_handler(httpd_req_t *req) {
+    char buf[512];
+    int ret, remaining = req->content_len;
+
+    if (remaining >= sizeof(buf)) {
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Body too large");
+        return ESP_FAIL;
+    }
+
+    ret = httpd_req_recv(req, buf, remaining);
+    if (ret <= 0) {
+        if (ret == HTTPD_SOCK_ERR_TIMEOUT) {
+            httpd_resp_send_408(req);
+        }
+        return ESP_FAIL;
+    }
+    buf[ret] = '\0';
+
+    cJSON *json = cJSON_Parse(buf);
+    if (!json) {
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+
+    cJSON *action_item = cJSON_GetObjectItem(json, "action");
+    if (!action_item || !cJSON_IsString(action_item)) {
+        cJSON_Delete(json);
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Missing action");
+        return ESP_FAIL;
+    }
+
+    const char *action = action_item->valuestring;
+
+    if (strcmp(action, "play") == 0) {
+        if (!is_playing && strlen(current_track) > 0) {
+            is_playing = true;
+            track_start_time_us = esp_timer_get_time();
+        }
+    } else if (strcmp(action, "pause") == 0) {
+        if (is_playing) {
+            is_playing = false;
+            int64_t now = esp_timer_get_time();
+            track_position_sec += (float)(now - track_start_time_us) / 1000000.0f;
+        }
+    } else if (strcmp(action, "seek") == 0) {
+        cJSON *pos_item = cJSON_GetObjectItem(json, "position");
+        if (pos_item && cJSON_IsNumber(pos_item)) {
+            track_position_sec = pos_item->valuedouble;
+            if (is_playing) {
+                track_start_time_us = esp_timer_get_time();
+            }
+        }
+    } else if (strcmp(action, "next") == 0) {
+        if (queue_count > 0) {
+            strncpy(current_track, audio_queue[0].filename, MAX_FILENAME_LEN - 1);
+            current_track[MAX_FILENAME_LEN - 1] = '\0';
+
+            for (int i = 0; i < queue_count - 1; i++) {
+                strncpy(audio_queue[i].filename, audio_queue[i+1].filename, MAX_FILENAME_LEN);
+            }
+            queue_count--;
+
+            is_playing = true;
+            track_position_sec = 0.0;
+            track_start_time_us = esp_timer_get_time();
+        } else {
+            current_track[0] = '\0';
+            is_playing = false;
+            track_position_sec = 0.0;
+        }
+    }
+
+    cJSON_Delete(json);
+    httpd_resp_send(req, "{\"success\":true}", 16);
+    return ESP_OK;
+}
+
+void register_audio_api_handlers(httpd_handle_t server) {
+    httpd_uri_t get_current = { "/audio/current", HTTP_GET, audio_current_handler, NULL };
+    httpd_register_uri_handler(server, &get_current);
+
+    httpd_uri_t get_queue = { "/audio/queue", HTTP_GET, audio_queue_get_handler, NULL };
+    httpd_register_uri_handler(server, &get_queue);
+
+    httpd_uri_t post_queue = { "/audio/queue", HTTP_POST, audio_queue_post_handler, NULL };
+    httpd_register_uri_handler(server, &post_queue);
+
+    httpd_uri_t delete_queue = { "/audio/queue", HTTP_DELETE, audio_queue_delete_handler, NULL };
+    httpd_register_uri_handler(server, &delete_queue);
+
+    httpd_uri_t post_state = { "/audio/state", HTTP_POST, audio_state_post_handler, NULL };
+    httpd_register_uri_handler(server, &post_state);
+}

--- a/main/audio_api.h
+++ b/main/audio_api.h
@@ -1,0 +1,8 @@
+#ifndef AUDIO_API_H
+#define AUDIO_API_H
+
+#include <esp_http_server.h>
+
+void register_audio_api_handlers(httpd_handle_t server);
+
+#endif // AUDIO_API_H

--- a/main/main.c
+++ b/main/main.c
@@ -51,6 +51,7 @@
 #include "lorawan.h"
 #include "bulletin_board.h"
 #include "bulletin_api.h"
+#include "audio_api.h"
 
 // --- Local Dependencies ---
 #include "dns_server.h"
@@ -865,13 +866,19 @@ static esp_err_t download_handler(httpd_req_t *req) {
     else if (strstr(filepath, ".mobi")) type = "application/x-mobipocket-ebook";
     else if (strstr(filepath, ".pdf")) type = "application/pdf";
     else if (strstr(filepath, ".txt")) type = "text/plain";
+    else if (strstr(filepath, ".mp3")) type = "audio/mpeg";
+    else if (strstr(filepath, ".m4a")) type = "audio/mp4";
+    else if (strstr(filepath, ".wav")) type = "audio/wav";
+    else if (strstr(filepath, ".ogg")) type = "audio/ogg";
 
     httpd_resp_set_type(req, type);
+    httpd_resp_set_hdr(req, "Accept-Ranges", "bytes");
 
-    // Set Content-Disposition header to encourage downloading
-    char disposition_header[256];
-    snprintf(disposition_header, sizeof(disposition_header), "attachment; filename=\"%s\"", decoded_file_param);
-    httpd_resp_set_hdr(req, "Content-Disposition", disposition_header);
+    if (!strstr(type, "audio/")) {
+        char disposition_header[256];
+        snprintf(disposition_header, sizeof(disposition_header), "attachment; filename=\"%s\"", decoded_file_param);
+        httpd_resp_set_hdr(req, "Content-Disposition", disposition_header);
+    }
 
     FILE *fd = fopen(filepath, "rb");
     if (!fd) {
@@ -879,6 +886,34 @@ static esp_err_t download_handler(httpd_req_t *req) {
         httpd_resp_send_500(req);
         return ESP_FAIL;
     }
+
+    size_t file_size = path_stat.st_size;
+    size_t start_byte = 0;
+    size_t end_byte = file_size - 1;
+    bool is_range_req = false;
+
+    char range_header[64];
+    if (httpd_req_get_hdr_value_str(req, "Range", range_header, sizeof(range_header)) == ESP_OK) {
+        is_range_req = true;
+        ESP_LOGI(TAG, "Range requested: %s", range_header);
+        if (sscanf(range_header, "bytes=%zu-%zu", &start_byte, &end_byte) == 1) {
+            end_byte = file_size - 1; // Only start_byte was provided
+        }
+        if (start_byte >= file_size) {
+            httpd_resp_send_err(req, HTTPD_416_REQUESTED_RANGE_NOT_SATISFIABLE, "Requested Range Not Satisfiable");
+            fclose(fd);
+            return ESP_FAIL;
+        }
+        httpd_resp_set_status(req, "206 Partial Content");
+        char content_range[128];
+        snprintf(content_range, sizeof(content_range), "bytes %zu-%zu/%zu", start_byte, end_byte, file_size);
+        httpd_resp_set_hdr(req, "Content-Range", content_range);
+        fseek(fd, start_byte, SEEK_SET);
+    } else {
+        httpd_resp_set_status(req, "200 OK");
+    }
+
+    size_t content_length = end_byte - start_byte + 1;
 
     char *chunk = malloc(4096);
     if (!chunk) {
@@ -888,9 +923,11 @@ static esp_err_t download_handler(httpd_req_t *req) {
         return ESP_FAIL;
     }
 
+    size_t remaining = content_length;
     size_t chunk_size;
     do {
-        chunk_size = fread(chunk, 1, 4096, fd);
+        size_t to_read = (remaining > 4096) ? 4096 : remaining;
+        chunk_size = fread(chunk, 1, to_read, fd);
         if (chunk_size > 0) {
             if (httpd_resp_send_chunk(req, chunk, chunk_size) != ESP_OK) {
                 fclose(fd);
@@ -898,8 +935,9 @@ static esp_err_t download_handler(httpd_req_t *req) {
                 ESP_LOGE(TAG, "File download chunk sending failed!");
                 return ESP_FAIL;
             }
+            remaining -= chunk_size;
         }
-    } while (chunk_size > 0);
+    } while (chunk_size > 0 && remaining > 0);
 
     httpd_resp_send_chunk(req, NULL, 0); // End response
     fclose(fd);
@@ -1396,6 +1434,7 @@ httpd_handle_t start_webserver(void) {
 
         // Register bulletin board API endpoints
         register_bulletin_api_handlers(server);
+        register_audio_api_handlers(server);
 
         // Handler for all other URIs (serves static files)
         httpd_uri_t static_uri = { "/*", HTTP_GET, static_file_handler, NULL };

--- a/main/web_assets/audio.html
+++ b/main/web_assets/audio.html
@@ -1,0 +1,266 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Audio Radio - E-Book Librarian</title>
+    <link rel="stylesheet" href="style.css">
+    <style>
+        .audio-container { background: rgba(0,0,0,0.3); padding: 20px; border-radius: 8px; margin-bottom: 20px; text-align: center; }
+        .queue-container { background: rgba(0,0,0,0.2); padding: 20px; border-radius: 8px; }
+        .queue-item { display: flex; justify-content: space-between; padding: 10px; border-bottom: 1px solid rgba(255,255,255,0.1); align-items: center;}
+        .queue-item:last-child { border-bottom: none; }
+        .library-section h3 { margin-top: 0; }
+        .btn-small { padding: 4px 8px; font-size: 0.8em; }
+        audio { width: 100%; margin-top: 15px; outline: none; }
+        .status-syncing { color: #f39c12; }
+        .status-playing { color: #2ecc71; }
+        .status-paused { color: #e74c3c; }
+        .now-playing { font-size: 1.2em; font-weight: bold; margin-bottom: 5px; color: #f5eedc; word-break: break-all; }
+        .sync-info { font-size: 0.9em; color: #8a7b6c; font-style: italic; }
+    </style>
+</head>
+<body>
+    <div id="audio-app">
+        <header class="app-header">
+            <h1>Audio Radio</h1>
+            <div style="display: flex; justify-content: flex-end; gap: 10px; padding-bottom: 10px;">
+                <button onclick="window.location.href='/index.html'">Back to Library</button>
+            </div>
+        </header>
+
+        <main class="app-main">
+            <div class="audio-container">
+                <h2>Now Playing</h2>
+                <div v-if="currentTrack">
+                    <div class="now-playing">{{ currentTrack }}</div>
+                    <div class="sync-info">
+                        Status: <span :class="statusClass">{{ statusText }}</span>
+                        <br>
+                        <small v-if="isDriver">(You are syncing the radio for others)</small>
+                    </div>
+
+                    <audio ref="audioPlayer" controls @play="onPlay" @pause="onPause" @seeked="onSeeked" @ended="onEnded">
+                        Your browser does not support the audio element.
+                    </audio>
+                    <button v-if="isDriver" @click="skipTrack" style="margin-top:10px;">Skip Track</button>
+                </div>
+                <div v-else>
+                    <p style="color: #8a7b6c; font-style: italic;">Nothing is currently playing. Add a track to the queue!</p>
+                </div>
+            </div>
+
+            <div style="display: flex; gap: 20px; flex-wrap: wrap;">
+                <div class="queue-container" style="flex: 1; min-width: 300px;">
+                    <h3>Up Next</h3>
+                    <div v-if="queue.length === 0" style="color: #8a7b6c; font-style: italic;">The queue is empty.</div>
+                    <div v-else>
+                        <div v-for="(track, index) in queue" :key="index" class="queue-item">
+                            <span>{{ index + 1 }}. {{ track }}</span>
+                            <button v-if="isAdmin" @click="removeFromQueue(index)" class="btn-small cancel-btn">Remove</button>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="library-section" style="flex: 1; min-width: 300px;">
+                    <h3>Available Audio Files (SD Card)</h3>
+                    <ul class="file-list">
+                        <li v-for="file in audioFiles" :key="file.name">
+                            <div class="file-info">
+                                <span class="file-title">{{ file.title || file.name }}</span>
+                            </div>
+                            <div class="transfer-controls">
+                                <button @click="addToQueue(file.name)">Add to Queue</button>
+                            </div>
+                        </li>
+                    </ul>
+                    <div v-if="audioFiles.length === 0" style="color: #8a7b6c; font-style: italic; padding: 10px;">
+                        No audio files (.mp3, .m4a, .wav) found in the library.
+                    </div>
+                </div>
+            </div>
+        </main>
+    </div>
+
+    <script src="vue.global.js"></script>
+    <script>
+        const { createApp } = Vue
+
+        createApp({
+            data() {
+                return {
+                    currentTrack: null,
+                    isPlaying: false,
+                    serverPosition: 0,
+                    queue: [],
+                    audioFiles: [],
+                    isAdmin: false,
+                    pollingInterval: null,
+                    isDriver: false, // If true, this client sends state updates to the server
+                    ignoreNextEvent: false,
+                    syncThreshold: 2.0 // Seconds diff before forcing sync
+                }
+            },
+            computed: {
+                statusClass() {
+                    return this.isPlaying ? 'status-playing' : 'status-paused';
+                },
+                statusText() {
+                    return this.isPlaying ? 'Playing (Live Sync)' : 'Paused';
+                }
+            },
+            methods: {
+                async fetchState() {
+                    try {
+                        const [stateRes, queueRes] = await Promise.all([
+                            fetch('/audio/current'),
+                            fetch('/audio/queue')
+                        ]);
+
+                        const stateData = await stateRes.json();
+                        this.queue = await queueRes.json();
+
+                        // Handle Track Change
+                        if (stateData.filename !== this.currentTrack) {
+                            this.currentTrack = stateData.filename;
+                            if (this.currentTrack) {
+                                // Important: We use &source=sd assuming audio is played from SD
+                                const url = `/download?file=${encodeURIComponent(this.currentTrack)}&source=sd`;
+                                this.$nextTick(() => {
+                                    if (this.$refs.audioPlayer) {
+                                        this.ignoreNextEvent = true;
+                                        this.$refs.audioPlayer.src = url;
+                                        this.$refs.audioPlayer.currentTime = stateData.position;
+                                        if (stateData.playing) {
+                                            this.$refs.audioPlayer.play().catch(e => {
+                                                console.log("Autoplay prevented. User interaction required.");
+                                                this.isPlaying = false;
+                                                this.isDriver = false;
+                                            });
+                                        }
+                                    }
+                                });
+                            }
+                        } else if (this.currentTrack && this.$refs.audioPlayer && !this.isDriver) {
+                            // Sync Logic for non-drivers
+                            const audio = this.$refs.audioPlayer;
+
+                            // Check play state sync
+                            if (stateData.playing !== !audio.paused) {
+                                this.ignoreNextEvent = true;
+                                if (stateData.playing) audio.play().catch(e=>console.log(e));
+                                else audio.pause();
+                            }
+
+                            // Check position sync
+                            if (stateData.playing && Math.abs(audio.currentTime - stateData.position) > this.syncThreshold) {
+                                console.log("Syncing position...", audio.currentTime, "->", stateData.position);
+                                this.ignoreNextEvent = true;
+                                audio.currentTime = stateData.position;
+                            }
+                        }
+
+                        this.isPlaying = stateData.playing;
+                        this.serverPosition = stateData.position;
+
+                        // Also check admin status if not checked
+                        if (!this.isAdminChecked) {
+                            fetch('/status').then(r=>r.json()).then(d => {
+                                this.isAdmin = !!d.is_admin;
+                                this.isAdminChecked = true;
+                            });
+                        }
+                    } catch (error) {
+                        console.error('Error fetching audio state:', error);
+                    }
+                },
+                async fetchAudioFiles() {
+                    try {
+                        const res = await fetch('/list-files?type=sd');
+                        const files = await res.json();
+                        // Filter only audio
+                        this.audioFiles = files.filter(f =>
+                            f.name.toLowerCase().endsWith('.mp3') ||
+                            f.name.toLowerCase().endsWith('.m4a') ||
+                            f.name.toLowerCase().endsWith('.wav') ||
+                            f.name.toLowerCase().endsWith('.ogg')
+                        );
+                    } catch (error) {
+                        console.error('Error fetching files:', error);
+                    }
+                },
+                async apiCall(endpoint, method, body) {
+                    const headers = { 'Content-Type': 'application/json' };
+                    let url = endpoint;
+                    if (this.isAdmin) {
+                        const key = localStorage.getItem('adminKey');
+                        if (key) url += `?key=${encodeURIComponent(key)}`;
+                    }
+                    return fetch(url, { method, headers, body: JSON.stringify(body) });
+                },
+                async addToQueue(filename) {
+                    await fetch('/audio/queue', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ filename })
+                    });
+                    this.fetchState();
+                },
+                async removeFromQueue(index) {
+                    await this.apiCall('/audio/queue', 'DELETE', { index });
+                    this.fetchState();
+                },
+                async updateServerState(action) {
+                    if (this.ignoreNextEvent) {
+                        this.ignoreNextEvent = false;
+                        return;
+                    }
+                    this.isDriver = true;
+                    let position = 0;
+                    if (this.$refs.audioPlayer) position = this.$refs.audioPlayer.currentTime;
+
+                    await fetch('/audio/state', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ action, position })
+                    });
+                    this.fetchState();
+                },
+                onPlay() { this.updateServerState('play'); },
+                onPause() {
+                    if (this.$refs.audioPlayer && this.$refs.audioPlayer.currentTime >= this.$refs.audioPlayer.duration) return; // handled by ended
+                    this.updateServerState('pause');
+                },
+                onSeeked() { this.updateServerState('seek'); },
+                async onEnded() {
+                    console.log("Track ended. Requesting next.");
+                    this.isDriver = true;
+                    await fetch('/audio/state', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ action: 'next', position: 0 })
+                    });
+                    this.fetchState();
+                },
+                async skipTrack() {
+                    this.isDriver = true;
+                    await fetch('/audio/state', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ action: 'next', position: 0 })
+                    });
+                    this.fetchState();
+                }
+            },
+            mounted() {
+                this.fetchAudioFiles();
+                this.fetchState();
+                this.pollingInterval = setInterval(this.fetchState, 3000); // Poll for sync
+            },
+            beforeUnmount() {
+                clearInterval(this.pollingInterval);
+            }
+        }).mount('#audio-app')
+    </script>
+</body>
+</html>

--- a/main/web_assets/index.html
+++ b/main/web_assets/index.html
@@ -18,6 +18,7 @@
             <h1>E-Book Librarian</h1>
             <div class="status-indicator" :class="statusClass"></div>
         <div style="display: flex; justify-content: flex-end; gap: 10px; padding-bottom: 10px; flex-wrap: wrap;">
+            <button onclick="window.location.href='/audio.html'">Audio Radio</button>
             <button onclick="window.location.href='/board.html'">Bulletin Board</button>
             <button onclick="window.location.href='/setup.html'">Setup</button>
             <button onclick="window.location.href='/admin.html'">Admin</button>


### PR DESCRIPTION
This submission implements the "Audio Radio" feature as requested by the user, using a synchronized file-hosting (pseudo-streaming) approach. 

The ESP32 acts as a file server and maintains a global playlist and track start times in memory. Connected clients (via `audio.html`) poll the backend to see what is playing and how far along it is, and then use HTTP `Range` requests to fetch exactly that part of the file and play it in sync with everyone else. This prevents the ESP32 from being overwhelmed by true continuous stream encoding while still delivering a synchronous "radio" experience.

---
*PR created automatically by Jules for task [5821904642794761734](https://jules.google.com/task/5821904642794761734) started by @LokiMetaSmith*