### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix buffer over-read in BLE GATT write handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,7 @@
 **Vulnerability:** Fixed-size buffers for query string extraction (Truncation Risk / DoS)
 **Learning:** ESP-IDF's `httpd_req_get_url_query_str` relies on the buffer size passed as an argument. If a fixed-size buffer is used (e.g., `char buf[512]`) and the client sends a query string longer than this buffer, the function returns `ESP_ERR_HTTPD_RESULT_TRUNC`. If this error isn't explicitly handled, or if the buffer truncates maliciously constructed input, it can bypass security checks, truncate data unexpectedly, or silently fail.
 **Prevention:** Always dynamically size the buffer for `httpd_req_get_url_query_str` using `size_t query_len = httpd_req_get_url_query_len(req);` and allocate memory as `malloc(query_len + 1)`. Ensure `free()` is called on all code paths.
+## 2024-05-18 - [Buffer Over-read]
+**Vulnerability:** Found a buffer over-read (CWE-125) in BLE GATT write handler where `strncpy` was used on `param->write.value`, which is not guaranteed to be null-terminated.
+**Learning:** `strncpy(dest, src, max_len)` reads from `src` until a null-terminator or `max_len`. If `src` comes from an untrusted network packet (like BLE) without null-termination, it will read past the end of the packet until it finds a null byte, leading to memory disclosure.
+**Prevention:** When dealing with length-specified external buffers (like `param->write.len`), use `memcpy` constrained by both the destination buffer size and the incoming length, and then manually null-terminate.

--- a/main/main.c
+++ b/main/main.c
@@ -1737,10 +1737,14 @@ static void gatts_profile_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_
             ESP_LOGI(GATTS_TAG, "GATT_WRITE_EVT, conn_id %d, trans_id %lu, handle %d", param->write.conn_id, (unsigned long)param->write.trans_id, param->write.handle);
 
             if (param->write.handle == gatt_db_handle_table[IDX_CHAR_VAL_SSID]) {
-                strncpy(wifi_ssid, (char*)param->write.value, sizeof(wifi_ssid) - 1);
+                size_t len = param->write.len < sizeof(wifi_ssid) - 1 ? param->write.len : sizeof(wifi_ssid) - 1;
+                memcpy(wifi_ssid, param->write.value, len);
+                wifi_ssid[len] = '\0';
                 ESP_LOGI(GATTS_TAG, "SSID set to: %s", wifi_ssid);
             } else if (param->write.handle == gatt_db_handle_table[IDX_CHAR_VAL_PASS]) {
-                strncpy(wifi_password, (char*)param->write.value, sizeof(wifi_password) - 1);
+                size_t len = param->write.len < sizeof(wifi_password) - 1 ? param->write.len : sizeof(wifi_password) - 1;
+                memcpy(wifi_password, param->write.value, len);
+                wifi_password[len] = '\0';
                 ESP_LOGI(GATTS_TAG, "Password set."); // Don't log the password
             } else if (param->write.handle == gatt_db_handle_table[IDX_CHAR_VAL_SAVE]) {
                 if (param->write.len == 1 && param->write.value[0] == 1) {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Buffer over-read (CWE-125) in BLE GATT write event handler. `strncpy` was used on `param->write.value` which is not guaranteed to be null-terminated.
🎯 **Impact:** Exposes adjacent memory (memory disclosure), which is logged to the console and saved to NVS.
🔧 **Fix:** Replaced `strncpy` with length-constrained `memcpy` and manual null termination, safely respecting the `param->write.len` bounds. Added a journal entry to `.jules/sentinel.md`.
✅ **Verification:** A code review confirmed the fix is secure and safe.

---
*PR created automatically by Jules for task [17606580703801977008](https://jules.google.com/task/17606580703801977008) started by @LokiMetaSmith*