### PR TITLE
⚡ Bolt: Combine audio state polling into single endpoint

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-06-20 - [Avoid polling FAT filesystem metadata on ESP-IDF]
 **Learning:** Polling `esp_vfs_fat_info` recursively traverses the FAT cluster chain to calculate free space. When called every second by frontend UI polling (like `/status`), this causes significant SPI bus latency and locks the VFS, creating a bottleneck that starves other FreeRTOS tasks (like network serving or HTTP handlers).
 **Action:** When implementing status endpoints in ESP-IDF that report filesystem metrics, ALWAYS cache the result of `esp_vfs_fat_info` using `xTaskGetTickCount()` (e.g. for 10 seconds), only bypassing the cache when an active file transfer is known to be modifying the disk.
+
+## 2024-06-22 - [Combine HTTP polling endpoints in ESP-IDF]
+**Learning:** On ESP-IDF backend, executing concurrent HTTP polling requests via `Promise.all` directly to multiple different endpoints like `/audio/current` and `/audio/queue` creates significant overhead. The ESP-IDF `httpd` component is optimized for lower overhead when dealing with single endpoints rather than parallel request connections from the same client, which can cause connection pooling exhaustion and block main threads.
+**Action:** When creating frontend UI interfaces for ESP-IDF devices, always combine grouped polling status queries (e.g. audio status, network status, queue data) into a unified `/state` endpoint rather than dispatching parallel `fetch()` connections to separate endpoints.

--- a/main/audio_api.c
+++ b/main/audio_api.c
@@ -30,34 +30,35 @@ static void send_json_response(httpd_req_t *req, cJSON *root) {
     cJSON_Delete(root);
 }
 
-static esp_err_t audio_current_handler(httpd_req_t *req) {
+static esp_err_t audio_state_get_handler(httpd_req_t *req) {
     cJSON *root = cJSON_CreateObject();
 
+    // Add current track info
+    cJSON *current = cJSON_CreateObject();
     if (strlen(current_track) > 0) {
-        cJSON_AddStringToObject(root, "filename", current_track);
-        cJSON_AddBoolToObject(root, "playing", is_playing);
+        cJSON_AddStringToObject(current, "filename", current_track);
+        cJSON_AddBoolToObject(current, "playing", is_playing);
 
         float current_pos = track_position_sec;
         if (is_playing) {
             int64_t now = esp_timer_get_time();
             current_pos += (float)(now - track_start_time_us) / 1000000.0f;
         }
-        cJSON_AddNumberToObject(root, "position", current_pos);
+        cJSON_AddNumberToObject(current, "position", current_pos);
     } else {
-        cJSON_AddNullToObject(root, "filename");
-        cJSON_AddBoolToObject(root, "playing", false);
-        cJSON_AddNumberToObject(root, "position", 0.0);
+        cJSON_AddNullToObject(current, "filename");
+        cJSON_AddBoolToObject(current, "playing", false);
+        cJSON_AddNumberToObject(current, "position", 0.0);
     }
+    cJSON_AddItemToObject(root, "current", current);
 
-    send_json_response(req, root);
-    return ESP_OK;
-}
-
-static esp_err_t audio_queue_get_handler(httpd_req_t *req) {
-    cJSON *root = cJSON_CreateArray();
+    // Add queue info
+    cJSON *queue = cJSON_CreateArray();
     for (int i = 0; i < queue_count; i++) {
-        cJSON_AddItemToArray(root, cJSON_CreateString(audio_queue[i].filename));
+        cJSON_AddItemToArray(queue, cJSON_CreateString(audio_queue[i].filename));
     }
+    cJSON_AddItemToObject(root, "queue", queue);
+
     send_json_response(req, root);
     return ESP_OK;
 }
@@ -253,11 +254,8 @@ static esp_err_t audio_state_post_handler(httpd_req_t *req) {
 }
 
 void register_audio_api_handlers(httpd_handle_t server) {
-    httpd_uri_t get_current = { "/audio/current", HTTP_GET, audio_current_handler, NULL };
-    httpd_register_uri_handler(server, &get_current);
-
-    httpd_uri_t get_queue = { "/audio/queue", HTTP_GET, audio_queue_get_handler, NULL };
-    httpd_register_uri_handler(server, &get_queue);
+    httpd_uri_t get_state = { "/audio/state", HTTP_GET, audio_state_get_handler, NULL };
+    httpd_register_uri_handler(server, &get_state);
 
     httpd_uri_t post_queue = { "/audio/queue", HTTP_POST, audio_queue_post_handler, NULL };
     httpd_register_uri_handler(server, &post_queue);

--- a/main/web_assets/audio.html
+++ b/main/web_assets/audio.html
@@ -112,13 +112,11 @@
             methods: {
                 async fetchState() {
                     try {
-                        const [stateRes, queueRes] = await Promise.all([
-                            fetch('/audio/current'),
-                            fetch('/audio/queue')
-                        ]);
+                        const res = await fetch('/audio/state');
+                        const data = await res.json();
 
-                        const stateData = await stateRes.json();
-                        this.queue = await queueRes.json();
+                        const stateData = data.current;
+                        this.queue = data.queue;
 
                         // Handle Track Change
                         if (stateData.filename !== this.currentTrack) {


### PR DESCRIPTION
💡 **What**: Combined the `/audio/current` and `/audio/queue` backend GET endpoints into a single unified `/audio/state` endpoint in `main/audio_api.c`. Updated `main/web_assets/audio.html` to fetch this new unified endpoint instead of doing parallel `Promise.all` requests.

🎯 **Why**: Executing parallel HTTP `fetch` requests via `Promise.all` directly to multiple different endpoints from the frontend creates significant connection overhead. The ESP-IDF `httpd` component is optimized for lower overhead when dealing with single endpoints rather than parallel request connections from the same client, which can cause connection pooling exhaustion and block main threads.

📊 **Impact**: Cuts the frontend audio sync polling request volume in half (from 2 requests every 3 seconds to 1 request every 3 seconds per client) and prevents potential ESP-IDF HTTP connection pool exhaustion caused by concurrent requests.

🔬 **Measurement**: Inspect the Network tab in the browser's developer tools on the `/audio.html` page to observe a single `/audio/state` polling request occurring every 3 seconds instead of two concurrent requests to `/audio/current` and `/audio/queue`.

---
*PR created automatically by Jules for task [10264070670369598374](https://jules.google.com/task/10264070670369598374) started by @LokiMetaSmith*