### PR TITLE
🎨 Palette: Add empty states to library book lists

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -10,3 +10,6 @@
 ## 2026-06-22 - Explicit Form Labels for Accessibility
 **Learning:** Found an accessibility issue pattern where inputs used only `placeholder` and `aria-label` attributes instead of explicit, visible `<label>` tags (e.g., in `setup.html` and the `admin.html` password gate). While `aria-label` provides screen reader context, relying solely on placeholder text is poor UX because the context disappears as soon as the user starts typing, which can be disorienting and fails to meet WCAG success criteria for visible labels.
 **Action:** Always pair inputs with visible, explicit `<label>` tags using the `for` and `id` attributes to ensure both visual persistence and screen reader compatibility.
+## 2026-06-23 - Empty states in data lists
+**Learning:** Found an interaction improvement opportunity where lists displaying dynamic data (like `localFiles` and `ereaderFiles` in `index.html`) lacked empty states. When a user has no files, displaying nothing leaves them unsure if the application is broken, loading, or genuinely empty. Adding empty states using `v-if` with clear, helpful messaging removes ambiguity and matches the established UX pattern in other areas like `audio.html`.
+**Action:** When working on UI lists or data tables that can be empty, always ensure there is a clear, styled empty state providing context to the user.

--- a/main/web_assets/index.html
+++ b/main/web_assets/index.html
@@ -57,6 +57,9 @@
                 </div>
 
                 <ul class="file-list">
+                    <li v-if="localFiles.length === 0" class="empty-state">
+                        No books found in the library.
+                    </li>
                     <li v-for="file in localFiles" :key="file.name">
                         <div class="file-info">
                             <span class="file-title">{{ file.title }}</span>
@@ -78,6 +81,9 @@
                 <h2>E-Reader</h2>
                 <div v-if="isEReaderConnected">
                     <ul class="file-list">
+                        <li v-if="ereaderFiles.length === 0" class="empty-state">
+                            No books found on the e-reader.
+                        </li>
                         <li v-for="file in ereaderFiles" :key="file.name">
                             <div class="file-info">
                                 <span class="file-title">{{ file.title }}</span>

--- a/main/web_assets/style.css
+++ b/main/web_assets/style.css
@@ -89,6 +89,12 @@ li:last-child {
     color: #a89f91;
     margin-top: 4px;
 }
+.empty-state {
+    color: #8a7b6c;
+    font-style: italic;
+    text-align: center;
+    padding: 10px;
+}
 button {
     background-color: #8c5a35;
     color: #f5eedc;


### PR DESCRIPTION
**💡 What:** Added explicit empty states for the "Local Library" and "E-Reader" file lists in `index.html`. These states display a clear "No books found" message when the arrays are empty.

**🎯 Why:** Previously, when a user had no books on their SD card or E-Reader, the lists rendered as completely blank space. This is a common UX pitfall that leaves users wondering if the page is still loading, if there's a backend error, or if it's genuinely empty. Providing clear, immediate feedback removes this ambiguity and aligns with existing patterns in the app (like `audio.html`).

**📸 Before/After:**
*(See verification screenshot attached to the run)*

**♿ Accessibility:** The empty states provide immediate visual feedback that the list is empty, helping users quickly understand the current state without having to guess based on a lack of content.

---
*PR created automatically by Jules for task [5311994466750867506](https://jules.google.com/task/5311994466750867506) started by @LokiMetaSmith*