### PR TITLE
⚡ Bolt: Replace Promise.all with sequential fetches

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-06-22 - [Combine HTTP polling endpoints in ESP-IDF]
 **Learning:** On ESP-IDF backend, executing concurrent HTTP polling requests via `Promise.all` directly to multiple different endpoints like `/audio/current` and `/audio/queue` creates significant overhead. The ESP-IDF `httpd` component is optimized for lower overhead when dealing with single endpoints rather than parallel request connections from the same client, which can cause connection pooling exhaustion and block main threads.
 **Action:** When creating frontend UI interfaces for ESP-IDF devices, always combine grouped polling status queries (e.g. audio status, network status, queue data) into a unified `/state` endpoint rather than dispatching parallel `fetch()` connections to separate endpoints.
+
+## 2024-10-27 - [Avoid Promise.all overhead for API fetches]
+**Learning:** On ESP-IDF backend, executing concurrent HTTP polling requests via `Promise.all` directly to multiple different endpoints like `/list-files?type=sd` and `/list-files?type=usb` creates significant overhead. The ESP-IDF `httpd` component is optimized for lower overhead when dealing with single endpoints sequentially rather than parallel request connections from the same client, which can cause connection pooling exhaustion and block main threads.
+**Action:** When fetching data from multiple endpoints in the frontend for ESP-IDF devices, always fetch them sequentially rather than in parallel with `Promise.all`.

--- a/main/web_assets/script.js
+++ b/main/web_assets/script.js
@@ -73,11 +73,11 @@ createApp({
         },
         async fetchFileLists() {
             try {
-                const [localRes, ereaderRes] = await Promise.all([
-                    fetch('/list-files?type=sd'),
-                    fetch('/list-files?type=usb')
-                ]);
+                // ⚡ Bolt: Fetch sequentially instead of Promise.all to avoid exhausting ESP-IDF connection pool
+                const localRes = await fetch('/list-files?type=sd');
                 this.localFiles = await localRes.json();
+
+                const ereaderRes = await fetch('/list-files?type=usb');
                 this.ereaderFiles = await ereaderRes.json();
             } catch (error) {
                 console.error('Error fetching file lists:', error);


### PR DESCRIPTION
💡 What:
Replaced concurrent `Promise.all` fetches to `/list-files` with sequential `await fetch()` calls in `main/web_assets/script.js`.

🎯 Why:
The ESP-IDF `httpd` backend on this embedded device handles concurrent connections poorly. Firing parallel polling requests via `Promise.all` exhausts the connection pool, creating significant processing overhead and latency, and risking blocking the main thread. Sequential fetches respect the backend's architecture.

📊 Impact:
Significantly reduces connection pool exhaustion and backend blocking during initial file list loading. The UI also benefits subtly by assigning and rendering the SD card list before waiting for the USB list to return.

🔬 Measurement:
Measured by testing sequential fetch completion in Playwright against the local frontend codebase. Monitored server stability when loading the main index.html page.

---
*PR created automatically by Jules for task [14983698990246551024](https://jules.google.com/task/14983698990246551024) started by @LokiMetaSmith*