### PR TITLE
🛡️ Sentinel: [CRITICAL] Prevent access to sensitive key files

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -21,3 +21,8 @@
 **Vulnerability:** Found a buffer over-read (CWE-125) in BLE GATT write handler where `strncpy` was used on `param->write.value`, which is not guaranteed to be null-terminated.
 **Learning:** `strncpy(dest, src, max_len)` reads from `src` until a null-terminator or `max_len`. If `src` comes from an untrusted network packet (like BLE) without null-termination, it will read past the end of the packet until it finds a null byte, leading to memory disclosure.
 **Prevention:** When dealing with length-specified external buffers (like `param->write.len`), use `memcpy` constrained by both the destination buffer size and the incoming length, and then manually null-terminate.
+
+## 2024-05-20 - [Prevent access to sensitive key files]
+**Vulnerability:** Static file handler and download handler allowed downloading sensitive files (`adminkey.json` and `.library_admin.key`), exposing admin credentials.
+**Learning:** Wildcard file serving endpoints must explicitly filter out sensitive application configuration and key files.
+**Prevention:** Implement file extension and filename blocking for `.key` and `adminkey.json` across all file reading and writing handlers.

--- a/main/main.c
+++ b/main/main.c
@@ -581,6 +581,13 @@ static esp_err_t static_file_handler(httpd_req_t *req) {
         return ESP_FAIL;
     }
 
+    // Prevent access to sensitive files
+    if (strstr(req->uri, "adminkey.json") != NULL || strstr(req->uri, ".key") != NULL) {
+        ESP_LOGE(TAG, "Attempted access to protected file: %s", req->uri);
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Forbidden");
+        return ESP_FAIL;
+    }
+
     // If we're hitting /generate_204 or other known captive portal probe endpoints, redirect them to root
     if (strstr(req->uri, "generate_204") != NULL || strstr(req->uri, "hotspot-detect") != NULL) {
         httpd_resp_set_status(req, "302 Temporary Redirect");
@@ -746,6 +753,12 @@ static esp_err_t upload_handler(httpd_req_t *req) {
         return ESP_FAIL;
     }
 
+    // Prevent overwriting sensitive files
+    if (strstr(filename, "adminkey.json") != NULL || strstr(filename, ".key") != NULL) {
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Forbidden");
+        return ESP_FAIL;
+    }
+
     char filepath[256];
     snprintf(filepath, sizeof(filepath), "%s/%s", MOUNT_POINT_SD, filename);
 
@@ -852,6 +865,13 @@ static esp_err_t download_handler(httpd_req_t *req) {
     // Basic path traversal prevention
     if (strstr(decoded_file_param, "..") != NULL) {
         httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid Filename");
+        return ESP_FAIL;
+    }
+
+    // Prevent access to sensitive files
+    if (strstr(decoded_file_param, "adminkey.json") != NULL || strstr(decoded_file_param, ".key") != NULL) {
+        ESP_LOGE(TAG, "Attempted access to protected file: %s", decoded_file_param);
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Forbidden");
         return ESP_FAIL;
     }
 
@@ -1165,6 +1185,14 @@ static esp_err_t transfer_file_handler(httpd_req_t *req) {
     if (strstr(filename, "..") != NULL) {
         cJSON_Delete(json);
         httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid Filename");
+        g_led_state = ebook_reader_connected ? LED_STATE_CONNECTED : LED_STATE_IDLE;
+        return ESP_FAIL;
+    }
+
+    // Prevent transferring sensitive files
+    if (strstr(filename, "adminkey.json") != NULL || strstr(filename, ".key") != NULL) {
+        cJSON_Delete(json);
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Forbidden");
         g_led_state = ebook_reader_connected ? LED_STATE_CONNECTED : LED_STATE_IDLE;
         return ESP_FAIL;
     }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The static file handler allowed downloading arbitrary files from SPIFFS (including `adminkey.json`), and the download handler allowed arbitrary file downloads from USB (including `.library_admin.key`), leading to authentication bypass.
🎯 **Impact:** An unauthenticated attacker could download the admin password hash/key or hardware security fob identity, resulting in full application compromise.
🔧 **Fix:** Added explicit filename and extension filtering (`adminkey.json` and `.key`) across `static_file_handler`, `download_handler`, `transfer_file_handler`, and `upload_handler` to explicitly reject access or modification.
✅ **Verification:** Attempting to GET `/adminkey.json` or download `.library_admin.key` now correctly returns HTTP 403 Forbidden.

---
*PR created automatically by Jules for task [4877344341413994496](https://jules.google.com/task/4877344341413994496) started by @LokiMetaSmith*