### PR TITLE
🎨 Palette: Add `aria-pressed` to board toggle buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2026-06-23 - Empty states in data lists
 **Learning:** Found an interaction improvement opportunity where lists displaying dynamic data (like `localFiles` and `ereaderFiles` in `index.html`) lacked empty states. When a user has no files, displaying nothing leaves them unsure if the application is broken, loading, or genuinely empty. Adding empty states using `v-if` with clear, helpful messaging removes ambiguity and matches the established UX pattern in other areas like `audio.html`.
 **Action:** When working on UI lists or data tables that can be empty, always ensure there is a clear, styled empty state providing context to the user.
+## 2026-06-24 - Accessibility for Toggle Buttons
+**Learning:** Found an interaction improvement opportunity in `board.html` where filtering, sorting, and category buttons visually indicated their active state via CSS classes (e.g., `active` or `active-Notice`), but this state wasn't communicated to screen readers. This leaves visually impaired users unaware of which filter or category is currently selected.
+**Action:** When creating toggle buttons or selectable tabs, always pair visual state classes with `aria-pressed="true"` or `aria-pressed="false"` attributes, and ensure these attributes are dynamically updated alongside the CSS classes in JavaScript logic.

--- a/main/web_assets/board.html
+++ b/main/web_assets/board.html
@@ -358,13 +358,13 @@ body {
     <div class="field field-cat">
       <label>Category</label>
       <div class="cat-btns">
-        <button class="cat-btn" onclick="setType('Notice',this)">📌 Notice</button>
-        <button class="cat-btn" onclick="setType('Offer', this)">🌱 Offer</button>
-        <button class="cat-btn" onclick="setType('Need',  this)">🤝 Need</button>
-        <button class="cat-btn" onclick="setType('Event', this)">📅 Event</button>
-        <button class="cat-btn" onclick="setType('Review', this)">📖 Review</button>
-        <button class="cat-btn" onclick="setType('Recomm',  this)">💡 Recomm.</button>
-        <button class="cat-btn" onclick="setType('Request', this)">🔍 Request</button>
+        <button class="cat-btn active-Notice" aria-pressed="true" onclick="setType('Notice',this)">📌 Notice</button>
+        <button class="cat-btn" aria-pressed="false" onclick="setType('Offer', this)">🌱 Offer</button>
+        <button class="cat-btn" aria-pressed="false" onclick="setType('Need',  this)">🤝 Need</button>
+        <button class="cat-btn" aria-pressed="false" onclick="setType('Event', this)">📅 Event</button>
+        <button class="cat-btn" aria-pressed="false" onclick="setType('Review', this)">📖 Review</button>
+        <button class="cat-btn" aria-pressed="false" onclick="setType('Recomm',  this)">💡 Recomm.</button>
+        <button class="cat-btn" aria-pressed="false" onclick="setType('Request', this)">🔍 Request</button>
       </div>
       <div class="char-hint"></div>
     </div>
@@ -381,26 +381,26 @@ body {
 
   <div class="expiry-row">
     <span class="expiry-label">Expires:</span>
-    <button class="exp-btn" onclick="setExpiry(24,  this)">1 day</button>
-    <button class="exp-btn" onclick="setExpiry(72,  this)">3 days</button>
-    <button class="exp-btn active" onclick="setExpiry(168, this)">1 week</button>
+    <button class="exp-btn" aria-pressed="false" onclick="setExpiry(24,  this)">1 day</button>
+    <button class="exp-btn" aria-pressed="false" onclick="setExpiry(72,  this)">3 days</button>
+    <button class="exp-btn active" aria-pressed="true" onclick="setExpiry(168, this)">1 week</button>
     <button class="post-btn" id="postBtn" onclick="doPost()">POST</button>
   </div>
 </div>
 
 <div class="filter-bar">
   <span class="filter-label">Show:</span>
-  <button class="ftab active" onclick="setFilter('',       this)">All</button>
-  <button class="ftab"        onclick="setFilter('Notice', this)">📌 Notice</button>
-  <button class="ftab"        onclick="setFilter('Offer',  this)">🌱 Offer</button>
-  <button class="ftab"        onclick="setFilter('Need',   this)">🤝 Need</button>
-  <button class="ftab"        onclick="setFilter('Event',  this)">📅 Event</button>
-  <button class="ftab"        onclick="setFilter('Review',  this)">📖 Review</button>
-  <button class="ftab"        onclick="setFilter('Recomm',   this)">💡 Recomm.</button>
-  <button class="ftab"        onclick="setFilter('Request',  this)">🔍 Request</button>
+  <button class="ftab active" aria-pressed="true" onclick="setFilter('',       this)">All</button>
+  <button class="ftab" aria-pressed="false" onclick="setFilter('Notice', this)">📌 Notice</button>
+  <button class="ftab" aria-pressed="false" onclick="setFilter('Offer',  this)">🌱 Offer</button>
+  <button class="ftab" aria-pressed="false" onclick="setFilter('Need',   this)">🤝 Need</button>
+  <button class="ftab" aria-pressed="false" onclick="setFilter('Event',  this)">📅 Event</button>
+  <button class="ftab" aria-pressed="false" onclick="setFilter('Review',  this)">📖 Review</button>
+  <button class="ftab" aria-pressed="false" onclick="setFilter('Recomm',   this)">💡 Recomm.</button>
+  <button class="ftab" aria-pressed="false" onclick="setFilter('Request',  this)">🔍 Request</button>
   <span class="sep"></span>
-  <button class="ftab active" id="sNew" onclick="setSort('new', this)">New</button>
-  <button class="ftab"        id="sExp" onclick="setSort('exp', this)">Expiring</button>
+  <button class="ftab active" id="sNew" aria-pressed="true" onclick="setSort('new', this)">New</button>
+  <button class="ftab"        id="sExp" aria-pressed="false" onclick="setSort('exp', this)">Expiring</button>
 </div>
 
 <div class="board" id="board"></div>
@@ -481,17 +481,24 @@ function setType(t, btn) {
   currentType = t;
   document.querySelectorAll('.cat-btn').forEach(b => {
     b.className = 'cat-btn';
+    b.setAttribute('aria-pressed', 'false');
   });
   btn.classList.add('active-' + t);
+  btn.setAttribute('aria-pressed', 'true');
 }
 // Set default active on load
 document.querySelector('.cat-btn').classList.add('active-Notice');
+document.querySelector('.cat-btn').setAttribute('aria-pressed', 'true');
 
 // ── Expiry selection ───────────────────────────
 function setExpiry(h, btn) {
   currentExpiry = h;
-  document.querySelectorAll('.exp-btn').forEach(b => b.classList.remove('active'));
+  document.querySelectorAll('.exp-btn').forEach(b => {
+    b.classList.remove('active');
+    b.setAttribute('aria-pressed', 'false');
+  });
   btn.classList.add('active');
+  btn.setAttribute('aria-pressed', 'true');
 }
 
 // ── Filter / sort ──────────────────────────────
@@ -500,15 +507,23 @@ function setFilter(f, btn) {
   document.querySelectorAll('.filter-bar .ftab').forEach(b => {
     if (b.id === 'sNew' || b.id === 'sExp') return;
     b.classList.remove('active');
+    b.setAttribute('aria-pressed', 'false');
   });
   btn.classList.add('active');
+  btn.setAttribute('aria-pressed', 'true');
   if (lastData.length) render(lastData);
 }
 
 function setSort(s, btn) {
   activeSort = s;
-  document.getElementById('sNew').classList.toggle('active', s === 'new');
-  document.getElementById('sExp').classList.toggle('active', s === 'exp');
+  const sNew = document.getElementById('sNew');
+  const sExp = document.getElementById('sExp');
+
+  sNew.classList.toggle('active', s === 'new');
+  sNew.setAttribute('aria-pressed', s === 'new' ? 'true' : 'false');
+
+  sExp.classList.toggle('active', s === 'exp');
+  sExp.setAttribute('aria-pressed', s === 'exp' ? 'true' : 'false');
 
   // ⚡ Bolt: Render locally instead of fetching from server to save 2 network requests
   if (lastData.length) render(lastData);


### PR DESCRIPTION
**💡 What:**
Added explicit `aria-pressed` states (`true` or `false`) to the category, filter, sort, and expiry buttons in the Bulletin Board (`board.html`). The states are now dynamically updated in the frontend JavaScript logic when the user interacts with the UI. 

**🎯 Why:**
Previously, these buttons communicated their "active" state purely through visual CSS class toggles (like `.active` or `.active-Notice`). This meant visually impaired users utilizing screen readers had no programmatic way of knowing which filter, category, or expiry option was currently selected, leading to an inaccessible filtering and posting experience.

**📸 Before/After:**
*(Visual UI remains unchanged. The changes affect the underlying DOM attributes for assistive technologies.)*

**♿ Accessibility:**
- Added `aria-pressed` support to all `.ftab`, `.cat-btn`, and `.exp-btn` elements to satisfy WCAG criteria for stateful toggle buttons. 
- Logged this learning in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [16613667465326566614](https://jules.google.com/task/16613667465326566614) started by @LokiMetaSmith*