### PR TITLE
🎨 Palette: Make admin feedback messages screen-reader accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-25 - Dynamic Feedback Accessibility in Vanilla JS
+**Learning:** In vanilla HTML/JS frontends, asynchronous status messages (like success/error toasts) injected directly into empty DOM nodes are completely invisible to screen readers without ARIA attributes.
+**Action:** When creating or modifying dynamic text feedback containers (`.feedback`, `.error`), always add `aria-live="polite"` for non-disruptive updates and `aria-live="assertive"` for critical errors to ensure screen readers announce the changes automatically.

--- a/main/web_assets/admin.html
+++ b/main/web_assets/admin.html
@@ -210,7 +210,7 @@ textarea.restore-area:focus { border-color: var(--accent-dark); }
   <label for="keyIn">Admin Access Key</label>
   <input type="password" id="keyIn" autocomplete="off">
   <button onclick="tryLogin()">Unlock 🔑</button>
-  <div class="error" id="gateErr"></div>
+  <div class="error" id="gateErr" aria-live="assertive"></div>
 </div>
 
 <!-- Admin controls (hidden until authenticated) -->
@@ -232,7 +232,7 @@ textarea.restore-area:focus { border-color: var(--accent-dark); }
         </div>
         <button class="btn" onclick="doSetKey()">Change Key</button>
       </div>
-      <div class="feedback" id="keyFb"></div>
+      <div class="feedback" id="keyFb" aria-live="polite"></div>
     </div>
   </div>
 
@@ -264,7 +264,7 @@ textarea.restore-area:focus { border-color: var(--accent-dark); }
       <div class="row">
         <button class="btn" onclick="doIdentity()">Save Identity</button>
       </div>
-      <div class="feedback" id="idFb"></div>
+      <div class="feedback" id="idFb" aria-live="polite"></div>
     </div>
   </div>
 
@@ -275,7 +275,7 @@ textarea.restore-area:focus { border-color: var(--accent-dark); }
         <button class="btn" onclick="loadPostList()">Refresh List</button>
         <button class="btn danger" onclick="confirmClear()">Clear All Posts</button>
       </div>
-      <div id="postListFb" class="feedback"></div>
+      <div id="postListFb" class="feedback" aria-live="polite"></div>
       <div id="postList"></div>
     </div>
   </div>
@@ -290,7 +290,7 @@ textarea.restore-area:focus { border-color: var(--accent-dark); }
         </div>
         <button class="btn" onclick="doSetLampColor()">Set Lamp Color</button>
       </div>
-      <div class="feedback" id="lampFb"></div>
+      <div class="feedback" id="lampFb" aria-live="polite"></div>
     </div>
   </div>
 
@@ -304,7 +304,7 @@ textarea.restore-area:focus { border-color: var(--accent-dark); }
       <div class="row">
         <button class="btn" onclick="doSetPublicUploads()">Save Upload Settings</button>
       </div>
-      <div class="feedback" id="uploadsFb"></div>
+      <div class="feedback" id="uploadsFb" aria-live="polite"></div>
     </div>
   </div>
 
@@ -314,7 +314,7 @@ textarea.restore-area:focus { border-color: var(--accent-dark); }
       <div class="row">
         <button class="btn danger" onclick="confirmFormatSD()">Format SD Card</button>
       </div>
-      <div class="feedback" id="storageFb"></div>
+      <div class="feedback" id="storageFb" aria-live="polite"></div>
     </div>
   </div>
 


### PR DESCRIPTION
**What**
Added `aria-live="polite"` to success/informational feedback containers (`.feedback`) and `aria-live="assertive"` to error containers (`.error`) within `admin.html`. Created a journal entry in `.jules/palette.md` to document this accessibility pattern.

**Why**
In vanilla JS frontends, displaying success or error messages by injecting text into empty DOM nodes means those updates are invisible to screen readers. Adding `aria-live` attributes fixes this by telling the screen reader to automatically announce the new text.

**Before/After**
* **Before:** `document.getElementById('keyFb').textContent = 'Key saved!'` silently appears on screen.
* **After:** With `aria-live="polite"`, the text appears visually AND is spoken aloud by screen readers as soon as it is injected into the DOM node.

**Accessibility**
Ensures all asynchronous status updates and error messages in the Admin panel are properly communicated to assistive technologies.

---
*PR created automatically by Jules for task [12260122748413596761](https://jules.google.com/task/12260122748413596761) started by @LokiMetaSmith*