### PR TITLE
⚡ Bolt: [performance improvement] Increase static file chunk size to 4KB

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-10-27 - [Avoid Promise.all overhead for API fetches]
 **Learning:** On ESP-IDF backend, executing concurrent HTTP polling requests via `Promise.all` directly to multiple different endpoints like `/list-files?type=sd` and `/list-files?type=usb` creates significant overhead. The ESP-IDF `httpd` component is optimized for lower overhead when dealing with single endpoints sequentially rather than parallel request connections from the same client, which can cause connection pooling exhaustion and block main threads.
 **Action:** When fetching data from multiple endpoints in the frontend for ESP-IDF devices, always fetch them sequentially rather than in parallel with `Promise.all`.
+
+## 2024-11-20 - [Increase static file chunk size to 4KB on ESP-IDF]
+**Learning:** In ESP-IDF's `httpd` component, serving static files (like large HTML/JS/CSS assets from SPIFFS) using small chunks (e.g. 1024 bytes) incurs significant overhead due to the high number of context switches, VFS reads (`fread`), and `httpd_resp_send_chunk` calls.
+**Action:** Always use larger chunk sizes (e.g., 4096 bytes) for static file handlers on the ESP32 to improve file transfer speed and reduce CPU usage, ensuring the buffer is heap-allocated (`malloc`) to prevent FreeRTOS task stack overflows.

--- a/main/main.c
+++ b/main/main.c
@@ -713,10 +713,10 @@ static esp_err_t static_file_handler(httpd_req_t *req) {
         return ESP_FAIL;
     }
 
-    char *chunk = malloc(1024);
+    char *chunk = malloc(4096);
     size_t chunk_size;
     do {
-        chunk_size = fread(chunk, 1, 1024, fd);
+        chunk_size = fread(chunk, 1, 4096, fd);
         if (chunk_size > 0) {
             if (httpd_resp_send_chunk(req, chunk, chunk_size) != ESP_OK) {
                 fclose(fd);


### PR DESCRIPTION
💡 **What**: Increased the HTTP response chunk size for the `static_file_handler` in `main/main.c` from 1024 bytes to 4096 bytes.

🎯 **Why**: When serving static assets (HTML/JS/CSS) from the SPIFFS partition over the ESP-IDF `httpd` server, smaller chunk sizes result in a higher number of file system reads (`fread`) and `httpd_resp_send_chunk` calls. This incurs significant overhead through context switching. Increasing the chunk size reduces this overhead and improves file serving speed. Memory is still heap-allocated using `malloc(4096)` to avoid FreeRTOS task stack overflows.

📊 **Impact**: Reduces the number of internal system calls and context switches during static file downloads by 75% for files larger than 1KB.

🔬 **Measurement**: Measure the time to load the web interface's assets via browser dev tools or measure the output performance of `curl http://<ip_address>/script.js`.

The `.jules/bolt.md` journal was updated to reflect this specific performance insight regarding the ESP-IDF component's chunking behavior.

---
*PR created automatically by Jules for task [17118053478401544373](https://jules.google.com/task/17118053478401544373) started by @LokiMetaSmith*