### PR TITLE
🎨 Palette: Add aria-live for screen readers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-06-25 - Dynamic Feedback Accessibility in Vanilla JS
 **Learning:** In vanilla HTML/JS frontends, asynchronous status messages (like success/error toasts) injected directly into empty DOM nodes are completely invisible to screen readers without ARIA attributes.
 **Action:** When creating or modifying dynamic text feedback containers (`.feedback`, `.error`), always add `aria-live="polite"` for non-disruptive updates and `aria-live="assertive"` for critical errors to ensure screen readers announce the changes automatically.
+## 2024-06-26 - Add aria-live to dynamic feedback
+**Learning:** Screen readers won't announce dynamic text changes (like error banners, status updates, or character count hints) in SPAs and interactive forms unless explicitly marked. Vanilla JS state changes can be silent to assistive technologies.
+**Action:** Always add `aria-live="assertive"` to critical error banners/messages and `aria-live="polite"` to status updates and hints in vanilla HTML/JS frontends when the DOM node dynamically updates text content.

--- a/main/web_assets/board.html
+++ b/main/web_assets/board.html
@@ -329,7 +329,7 @@ body {
 <body>
 
 <header class="site-header">
-  <div id="systemBanner" style="display:none;background:#ffcc00;color:#333;padding:10px;margin:0 24px 15px 24px;border-radius:5px;border:1px solid #e6b800;">
+  <div id="systemBanner" aria-live="assertive" style="display:none;background:#ffcc00;color:#333;padding:10px;margin:0 24px 15px 24px;border-radius:5px;border:1px solid #e6b800;">
     <ul id="systemErrorsList" style="margin:0;padding-left:20px;"></ul>
   </div>
   <div class="header-title-block">
@@ -341,7 +341,7 @@ body {
     <div id="postCount">— posts</div>
   </div>
 </header>
-<div id="fullBanner" style="display:none;background:#a30000;color:#fff;
+<div id="fullBanner" aria-live="assertive" style="display:none;background:#a30000;color:#fff;
      text-align:center;padding:10px 16px;font-weight:600">
   📋 This board is currently full. Check back once some posts have expired. 📋
 </div>
@@ -352,7 +352,7 @@ body {
       <label for="nameIn">Your Name</label>
       <input id="nameIn" maxlength="24" placeholder="neighbor"
              autocomplete="off" spellcheck="false">
-      <div class="char-hint" id="nameHint"></div>
+      <div class="char-hint" id="nameHint" aria-live="polite"></div>
     </div>
 
     <div class="field field-cat">
@@ -374,7 +374,7 @@ body {
       <textarea id="msgIn" maxlength="300"
                 placeholder="What's on the board?"
                 spellcheck="false"></textarea>
-      <div class="char-hint" id="msgHint"></div>
+      <div class="char-hint" id="msgHint" aria-live="polite"></div>
     </div>
 
   </div>

--- a/main/web_assets/index.html
+++ b/main/web_assets/index.html
@@ -9,11 +9,15 @@
 <body>
     <div id="app">
         <header class="app-header">
-        <div v-if="systemErrors.length > 0" class="system-banner error-banner">
-            <p v-for="err in systemErrors" :key="err">⚠️ {{ err }}</p>
+        <div aria-live="assertive">
+            <div v-if="systemErrors.length > 0" class="system-banner error-banner">
+                <p v-for="err in systemErrors" :key="err">⚠️ {{ err }}</p>
+            </div>
         </div>
-        <div v-if="systemStatus.length > 0" class="system-banner status-banner">
-            <p v-for="msg in systemStatus" :key="msg">🔄 {{ msg }}</p>
+        <div aria-live="polite">
+            <div v-if="systemStatus.length > 0" class="system-banner status-banner">
+                <p v-for="msg in systemStatus" :key="msg">🔄 {{ msg }}</p>
+            </div>
         </div>
             <h1>E-Book Librarian</h1>
             <div class="status-indicator" :class="statusClass"></div>
@@ -53,7 +57,9 @@
                             {{ isUploading ? 'Uploading...' : 'Upload' }}
                         </button>
                     </form>
-                    <p class="error-message" v-if="uploadError">{{ uploadError }}</p>
+                    <div aria-live="assertive">
+                        <p class="error-message" v-if="uploadError">{{ uploadError }}</p>
+                    </div>
                 </div>
 
                 <ul class="file-list">
@@ -108,7 +114,9 @@
             </div>
         </main>
         <footer class="app-footer">
-            <p class="error-message" v-if="transfer.error">{{ transfer.error }}</p>
+            <div aria-live="assertive">
+                <p class="error-message" v-if="transfer.error">{{ transfer.error }}</p>
+            </div>
             <div class="footer-actions">
                 <button @click="enterSleepMode" class="sleep-btn">Enter Sleep Mode</button>
             </div>

--- a/main/web_assets/setup.html
+++ b/main/web_assets/setup.html
@@ -32,7 +32,7 @@
             </div>
             <button type="submit">Connect</button>
         </form>
-        <div id="status"></div>
+        <div id="status" aria-live="polite"></div>
         <div style="margin-top: 20px;">
             <button type="button" onclick="window.location.href='/index.html'" style="background-color: #6c757d;">Back to Library</button>
         </div>


### PR DESCRIPTION
### 💡 What
Added `aria-live` attributes to dynamic text feedback containers across the frontend application (`board.html`, `index.html`, and `setup.html`).

### 🎯 Why
Screen readers (like VoiceOver or NVDA) do not automatically announce text changes in single-page applications or vanilla JS dynamic forms unless the container is explicitly marked with an `aria-live` attribute. This change ensures that critical system errors, upload statuses, and character count warnings are proactively announced to users relying on assistive technologies without them needing to hunt for the feedback.

### 📸 Before/After
- **Before:** When an error occurred during a file upload or the board became full, the text appeared visually, but screen reader users received no auditory feedback, leaving them unaware of the failure or status update.
- **After:** The browser automatically reads out the new text content of these banners and hints as soon as they are injected or updated in the DOM.

### ♿ Accessibility
- Added `aria-live="assertive"` to critical error messages (system error banners, upload errors, full board banner) to immediately interrupt and alert the user.
- Added `aria-live="polite"` to non-critical status updates and character count hints (`#msgHint`, `#nameHint`, system status banner) to announce when the screen reader is idle.
- Refactored the Vue.js implementation in `index.html` to place `aria-live` on persistent wrapper `div` elements, rather than the conditionally rendered `v-if` nodes directly. This is a best practice to ensure assistive tech registers the live region on page load and reliably captures subsequent DOM mutations.

---
*PR created automatically by Jules for task [1213391096757366092](https://jules.google.com/task/1213391096757366092) started by @LokiMetaSmith*