### PR TITLE
⚡ Bolt: [performance improvement] Speed up file transfers by removing FAT chain polling bottleneck

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2024-11-20 - [Increase static file chunk size to 4KB on ESP-IDF]
 **Learning:** In ESP-IDF's `httpd` component, serving static files (like large HTML/JS/CSS assets from SPIFFS) using small chunks (e.g. 1024 bytes) incurs significant overhead due to the high number of context switches, VFS reads (`fread`), and `httpd_resp_send_chunk` calls.
 **Action:** Always use larger chunk sizes (e.g., 4096 bytes) for static file handlers on the ESP32 to improve file transfer speed and reduce CPU usage, ensuring the buffer is heap-allocated (`malloc`) to prevent FreeRTOS task stack overflows.
+
+## 2024-11-21 - [Avoid bypassing VFS cache during file transfers on ESP-IDF]
+**Learning:** Polling `esp_vfs_fat_info` repeatedly during active file transfers (e.g., by bypassing the cache condition when `g_transfer_progress.active` is true) recursively traverses the FAT cluster chain and locks the VFS. This significantly slows down active file VFS operations like the transfer itself, drastically decreasing SPI bus availability and file transfer speeds.
+**Action:** Even when a file transfer is active, rely on the time-based cache for `esp_vfs_fat_info` to prevent starving the SPI bus and throttling the transfer process itself.

--- a/main/main.c
+++ b/main/main.c
@@ -1057,7 +1057,8 @@ static esp_err_t status_handler(httpd_req_t *req) {
 
     if (g_sd_card_initialized) {
         TickType_t now_ticks = xTaskGetTickCount();
-        if (!sd_info_cached || (now_ticks - last_sd_info_ticks) > pdMS_TO_TICKS(SD_INFO_CACHE_DURATION_MS) || g_transfer_progress.active) {
+        // ⚡ Bolt: Removed `|| g_transfer_progress.active` to prevent `esp_vfs_fat_info` from locking VFS during transfers
+        if (!sd_info_cached || (now_ticks - last_sd_info_ticks) > pdMS_TO_TICKS(SD_INFO_CACHE_DURATION_MS)) {
             uint64_t out_total_bytes, out_free_bytes;
             if (esp_vfs_fat_info(MOUNT_POINT_SD, &out_total_bytes, &out_free_bytes) == ESP_OK) {
                 cached_sd_total_mb = out_total_bytes / (1024 * 1024);


### PR DESCRIPTION
### 💡 What
Removed `|| g_transfer_progress.active` from the condition that manages SD card information caching in `status_handler` within `main/main.c`.

### 🎯 Why
When this API is polled (e.g., every second by the frontend to show transfer progress), bypassing the cache forces `esp_vfs_fat_info` to run synchronously. This function recursively traverses the FAT cluster chain to calculate free space, which locks the VFS and monopolizes the SPI bus. By doing this continuously during an active file transfer, the actual transfer task is starved of SPI bus access, creating a massive bottleneck and artificially throttling transfer speeds.

### 📊 Impact
* Drastically improves file transfer speeds by preventing the frontend status poller from locking the SPI bus.
* Reduces CPU usage during transfers by serving cached SD card metrics.
* Reported SD free space during a transfer will now accurately reflect reality every `SD_INFO_CACHE_DURATION_MS` (10 seconds) instead of continuously thrashing the disk.

### 🔬 Measurement
1. Initiate a large file transfer (e.g., uploading an audiobook).
2. Measure the time to completion before and after this patch.
3. Observe the system responsiveness; the frontend UI should no longer cause the file transfer progress to stutter or halt while `esp_vfs_fat_info` executes.

---
*PR created automatically by Jules for task [12969251676837443719](https://jules.google.com/task/12969251676837443719) started by @LokiMetaSmith*