### PR TITLE
🛡️ Sentinel: [HIGH] Fix integer overflow in HTTP handlers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -8,3 +8,7 @@
 **Vulnerability:** The `admin_delete_post_handler` and `admin_clear_handler` endpoints in `main/bulletin_api.c` previously used `HTTP_GET` for destructive actions (deleting and clearing data) and took parameters via the query string.
 **Learning:** Using `GET` for state-modifying actions violates REST principles and introduces security risks, such as exposing sensitive parameters in logs and enabling Cross-Site Request Forgery (CSRF). CSRF allows attackers to execute unintended actions if an authenticated user visits a malicious link. Additionally, when using `req->content_len` use `size_t` rather than `int` to avoid integer overflow which could cause heap buffer overflows.
 **Prevention:** Always use `HTTP_POST`, `HTTP_PUT`, or `HTTP_DELETE` for operations that alter application state. Pass sensitive parameters or data in the request body (e.g., as a JSON payload) rather than the query string. And ensure safe types when working with request bodies lengths.
+## 2025-02-12 - Integer Overflow in HTTP Handlers
+**Vulnerability:** `req->content_len` was being assigned to an `int` instead of a `size_t` in `audio_api.c`, `bulletin_api.c`, and `main.c`.
+**Learning:** Using an `int` to store `req->content_len` can lead to integer overflow and heap buffer overflow vulnerabilities when allocating dynamic memory for payloads in ESP-IDF.
+**Prevention:** Always store `req->content_len` in a `size_t` variable when handling ESP-IDF HTTP requests.

--- a/main/audio_api.c
+++ b/main/audio_api.c
@@ -65,7 +65,8 @@ static esp_err_t audio_state_get_handler(httpd_req_t *req) {
 
 static esp_err_t audio_queue_post_handler(httpd_req_t *req) {
     char buf[256];
-    int ret, remaining = req->content_len;
+    int ret;
+    size_t remaining = req->content_len;
 
     if (remaining >= sizeof(buf)) {
         httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Body too large");
@@ -134,7 +135,8 @@ static esp_err_t audio_queue_delete_handler(httpd_req_t *req) {
     }
 
     char buf[256];
-    int ret, remaining = req->content_len;
+    int ret;
+    size_t remaining = req->content_len;
 
     if (remaining >= sizeof(buf)) {
         httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Body too large");
@@ -178,7 +180,8 @@ static esp_err_t audio_queue_delete_handler(httpd_req_t *req) {
 
 static esp_err_t audio_state_post_handler(httpd_req_t *req) {
     char buf[512];
-    int ret, remaining = req->content_len;
+    int ret;
+    size_t remaining = req->content_len;
 
     if (remaining >= sizeof(buf)) {
         httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Body too large");

--- a/main/bulletin_api.c
+++ b/main/bulletin_api.c
@@ -70,7 +70,8 @@ static esp_err_t board_messages_handler(httpd_req_t *req) {
 }
 
 static esp_err_t board_post_handler(httpd_req_t *req) {
-    int ret, remaining = req->content_len;
+    int ret;
+    size_t remaining = req->content_len;
     if (remaining >= 1024) {
         httpd_resp_send_408(req);
         return ESP_FAIL;
@@ -130,7 +131,8 @@ static esp_err_t board_post_handler(httpd_req_t *req) {
 }
 
 static esp_err_t admin_auth_handler(httpd_req_t *req) {
-    int ret, remaining = req->content_len;
+    int ret;
+    size_t remaining = req->content_len;
     if (remaining >= 256) {
         httpd_resp_send_408(req);
         return ESP_FAIL;

--- a/main/main.c
+++ b/main/main.c
@@ -583,7 +583,8 @@ static esp_err_t setup_get_handler(httpd_req_t *req) {
 // Handler to save credentials and restart
 static esp_err_t save_credentials_post_handler(httpd_req_t *req) {
     char buf[128];
-    int ret, remaining = req->content_len;
+    int ret;
+    size_t remaining = req->content_len;
 
     if (remaining > sizeof(buf) -1) {
         ESP_LOGE(TAG, "Content too long");
@@ -834,7 +835,7 @@ static esp_err_t upload_handler(httpd_req_t *req) {
         return ESP_FAIL;
     }
 
-        int remaining = req->content_len;
+        size_t remaining = req->content_len;
 
     while (remaining > 0) {
         int ret = httpd_req_recv(req, recv_buf, MIN(remaining, 4096));


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The HTTP handlers assigned `req->content_len` to an `int` variable instead of `size_t`.
🎯 **Impact:** This integer overflow vulnerability could be exploited to cause heap buffer overflows when memory is dynamically allocated based on the payload length, potentially leading to arbitrary code execution or Denial of Service (DoS) attacks.
🔧 **Fix:** Changed the variable type of `remaining` and `req->content_len` assignments from `int` to `size_t` in all file-handling and POST HTTP handlers across `main/audio_api.c`, `main/bulletin_api.c`, and `main/main.c`.
✅ **Verification:** Verified that the replacement of `int` with `size_t` was correctly applied using `git diff`. The `cJSON` modifications were removed to keep the patch focused and under 50 lines. The code review confirmed the safety and accuracy of the changes.

---
*PR created automatically by Jules for task [8791151775451509426](https://jules.google.com/task/8791151775451509426) started by @LokiMetaSmith*