### PR TITLE
⚡ Bolt: Stream large catalog.json in chunks to prevent OOM

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,7 @@
 ## 2024-11-21 - [Avoid bypassing VFS cache during file transfers on ESP-IDF]
 **Learning:** Polling `esp_vfs_fat_info` repeatedly during active file transfers (e.g., by bypassing the cache condition when `g_transfer_progress.active` is true) recursively traverses the FAT cluster chain and locks the VFS. This significantly slows down active file VFS operations like the transfer itself, drastically decreasing SPI bus availability and file transfer speeds.
 **Action:** Even when a file transfer is active, rely on the time-based cache for `esp_vfs_fat_info` to prevent starving the SPI bus and throttling the transfer process itself.
+
+## 2024-06-27 - [Stream large JSON files instead of loading into RAM on ESP32]
+**Learning:** Loading large dynamically generated files like `catalog.json` entirely into RAM using `malloc(fsize + 1)` and `httpd_resp_send()` causes huge memory spikes and can crash the ESP32 due to heap exhaustion when the library grows.
+**Action:** Always serve large files using `httpd_resp_send_chunk` with a fixed-size buffer (e.g. 4KB), even for API endpoints returning JSON, as the browser's `fetch` API transparently handles chunked transfer encoding without requiring frontend changes.

--- a/main/main.c
+++ b/main/main.c
@@ -1134,23 +1134,28 @@ static esp_err_t list_files_handler(httpd_req_t *req) {
         snprintf(catalog_path, sizeof(catalog_path), "%s/catalog.json", mount_path);
         FILE *f = fopen(catalog_path, "r");
         if (f) {
-            fseek(f, 0, SEEK_END);
-            long fsize = ftell(f);
-            fseek(f, 0, SEEK_SET);
-
-            char *json_data = malloc(fsize + 1);
-            if (json_data) {
-                fread(json_data, 1, fsize, f);
-                json_data[fsize] = '\0';
-                fclose(f);
-
-                httpd_resp_set_type(req, "application/json");
-                httpd_resp_send(req, json_data, fsize);
-
-                free(json_data);
-                return ESP_OK;
+            httpd_resp_set_type(req, "application/json");
+            // ⚡ Bolt: Stream large catalog.json in 4KB chunks instead of loading entirely into RAM with malloc()
+            // This prevents OOM crashes on ESP32 by turning O(N) heap usage into O(1), and improves TTFB.
+            char *chunk = malloc(4096);
+            if (chunk) {
+                size_t chunk_size;
+                do {
+                    chunk_size = fread(chunk, 1, 4096, f);
+                    if (chunk_size > 0) {
+                        if (httpd_resp_send_chunk(req, chunk, chunk_size) != ESP_OK) {
+                            ESP_LOGE(TAG, "Failed to send catalog.json chunk");
+                            break;
+                        }
+                    }
+                } while (chunk_size == 4096);
+                httpd_resp_send_chunk(req, NULL, 0); // End chunked response
+                free(chunk);
+            } else {
+                httpd_resp_send_500(req);
             }
             fclose(f);
+            return ESP_OK;
         }
     }
 


### PR DESCRIPTION
### 💡 What
Refactored `list_files_handler` in `main.c` to stream the `catalog.json` file using `httpd_resp_send_chunk` with a fixed 4KB buffer, instead of allocating a contiguous buffer for the entire file length using `malloc`.

### 🎯 Why
As the library's `catalog.json` grows large, allocating a contiguous block of memory (`malloc(fsize + 1)`) can easily exhaust the ESP32's limited heap, leading to memory fragmentation and fatal OOM crashes. 

### 📊 Impact
* **Reduces peak memory usage** from O(N) (where N is file size) down to a constant O(1) 4KB buffer.
* **Improves Time to First Byte (TTFB)** as the backend can begin transmitting the JSON file over the network immediately, rather than waiting for the entire disk read to complete first.
* The browser's `fetch` API transparently handles chunked transfer encoding, requiring no frontend changes.

### 🔬 Measurement
This can be verified by observing the free heap (`esp_get_free_heap_size()`) during a request to `/list-files?type=sd` when a large library is present, or simply verifying that the endpoint no longer crashes the device when `catalog.json` exceeds the available heap.

---
*PR created automatically by Jules for task [13796971401580276988](https://jules.google.com/task/13796971401580276988) started by @LokiMetaSmith*