### PR TITLE
🎨 Palette: Add CTA and empty-state classes to audio player lists

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -16,3 +16,6 @@
 ## 2026-06-24 - Accessibility for Toggle Buttons
 **Learning:** Found an interaction improvement opportunity in `board.html` where filtering, sorting, and category buttons visually indicated their active state via CSS classes (e.g., `active` or `active-Notice`), but this state wasn't communicated to screen readers. This leaves visually impaired users unaware of which filter or category is currently selected.
 **Action:** When creating toggle buttons or selectable tabs, always pair visual state classes with `aria-pressed="true"` or `aria-pressed="false"` attributes, and ensure these attributes are dynamically updated alongside the CSS classes in JavaScript logic.
+## 2024-06-25 - Empty states in data lists (Audio player)
+**Learning:** Continued the established pattern of implementing explicit empty states for dynamic lists. The audio player UI (`audio.html`) displayed raw text when the queue or library was empty instead of utilizing the `empty-state` class that provides consistent spacing and coloring. Furthermore, the empty library state lacked a call-to-action (CTA) guiding users to the main page to upload files.
+**Action:** Always ensure that when `v-if="items.length === 0"` is used, the containing element has `class="empty-state"`, and contains a helpful CTA when applicable.

--- a/main/web_assets/audio.html
+++ b/main/web_assets/audio.html
@@ -53,7 +53,9 @@
             <div style="display: flex; gap: 20px; flex-wrap: wrap;">
                 <div class="queue-container" style="flex: 1; min-width: 300px;">
                     <h3>Up Next</h3>
-                    <div v-if="queue.length === 0" style="color: #8a7b6c; font-style: italic;">The queue is empty.</div>
+                    <div v-if="queue.length === 0" class="empty-state">
+                        The queue is empty. Add a track from the library below!
+                    </div>
                     <div v-else>
                         <div v-for="(track, index) in queue" :key="index" class="queue-item">
                             <span>{{ index + 1 }}. {{ track }}</span>
@@ -74,8 +76,9 @@
                             </div>
                         </li>
                     </ul>
-                    <div v-if="audioFiles.length === 0" style="color: #8a7b6c; font-style: italic; padding: 10px;">
-                        No audio files (.mp3, .m4a, .wav) found in the library.
+                    <div v-if="audioFiles.length === 0" class="empty-state">
+                        No audio files (.mp3, .m4a, .wav) found in the library.<br>
+                        <span style="font-size: 0.9em; margin-top: 5px; display: inline-block;">Go to the <a href="/" style="color: inherit; text-decoration: underline;">main library</a> to upload audio files.</span>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
💡 **What:**
Updated the empty state messages in `main/web_assets/audio.html` for both the Queue and Available Audio Files lists to use the standard `.empty-state` CSS class, and added explicit Call-To-Action (CTA) text and links.

🎯 **Why:**
When users encounter empty lists, unstyled default text can feel broken or unhelpful. By using the system's `.empty-state` styling (consistent coloring and italics), we provide a polished look. Adding CTA text ("Add a track from the library below!" and a link back to the main library) actively guides the user on how to resolve the empty state, improving the overall intuitive feel of the application.

📸 **Before/After:**
Before, the queue displayed unstyled text `The queue is empty.`, and the library displayed `No audio files (.mp3, .m4a, .wav) found in the library.`. Now, both use the consistent `.empty-state` class, and the library includes a direct link: "Go to the main library to upload audio files."

♿ **Accessibility:**
The CTA link improves navigability for all users, including keyboard and screen reader users, by providing a direct semantic path (`<a href="/">`) to the location where they can resolve the empty state without having to guess.

---
*PR created automatically by Jules for task [8341448007491996000](https://jules.google.com/task/8341448007491996000) started by @LokiMetaSmith*