### PR TITLE
⚡ Bolt: Replace O(N) strncpy loops with memmove and remove unused snprintf in list_files_handler

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2024-06-27 - [Stream large JSON files instead of loading into RAM on ESP32]
 **Learning:** Loading large dynamically generated files like `catalog.json` entirely into RAM using `malloc(fsize + 1)` and `httpd_resp_send()` causes huge memory spikes and can crash the ESP32 due to heap exhaustion when the library grows.
 **Action:** Always serve large files using `httpd_resp_send_chunk` with a fixed-size buffer (e.g. 4KB), even for API endpoints returning JSON, as the browser's `fetch` API transparently handles chunked transfer encoding without requiring frontend changes.
+
+## 2024-11-23 - [Replace O(N) strncpy with memmove]
+**Learning:** In C/ESP-IDF backend code, using a `for` loop with `strncpy` to shift array elements (like an audio queue) is O(N) time complexity and incurs unnecessary overhead by traversing each string to pad with zeroes.
+**Action:** Always replace `for` loops that manually copy adjacent structures or strings with a single `memmove` operation to shift the entire block in memory. This is vastly faster and safer.

--- a/main/audio_api.c
+++ b/main/audio_api.c
@@ -108,8 +108,8 @@ static esp_err_t audio_queue_post_handler(httpd_req_t *req) {
             current_track[MAX_FILENAME_LEN - 1] = '\0';
 
             // Remove from queue
-            for (int i = 0; i < queue_count - 1; i++) {
-                strncpy(audio_queue[i].filename, audio_queue[i+1].filename, MAX_FILENAME_LEN);
+            if (queue_count > 1) {
+                memmove(&audio_queue[0], &audio_queue[1], (queue_count - 1) * sizeof(audio_track_t));
             }
             queue_count--;
 
@@ -167,8 +167,8 @@ static esp_err_t audio_queue_delete_handler(httpd_req_t *req) {
 
     int index = index_item->valueint;
     if (index >= 0 && index < queue_count) {
-        for (int i = index; i < queue_count - 1; i++) {
-            strncpy(audio_queue[i].filename, audio_queue[i+1].filename, MAX_FILENAME_LEN);
+        if (index < queue_count - 1) {
+            memmove(&audio_queue[index], &audio_queue[index + 1], (queue_count - 1 - index) * sizeof(audio_track_t));
         }
         queue_count--;
     }
@@ -236,8 +236,8 @@ static esp_err_t audio_state_post_handler(httpd_req_t *req) {
             strncpy(current_track, audio_queue[0].filename, MAX_FILENAME_LEN - 1);
             current_track[MAX_FILENAME_LEN - 1] = '\0';
 
-            for (int i = 0; i < queue_count - 1; i++) {
-                strncpy(audio_queue[i].filename, audio_queue[i+1].filename, MAX_FILENAME_LEN);
+            if (queue_count > 1) {
+                memmove(&audio_queue[0], &audio_queue[1], (queue_count - 1) * sizeof(audio_track_t));
             }
             queue_count--;
 

--- a/main/main.c
+++ b/main/main.c
@@ -1179,19 +1179,10 @@ static esp_err_t list_files_handler(httpd_req_t *req) {
                 cJSON *file_obj = cJSON_CreateObject();
                 cJSON_AddStringToObject(file_obj, "name", dir->d_name);
 
-                // For EPUBs, try to parse metadata
+                // For EPUBs, miniz not available yet, just use filename
                 if (strstr(dir->d_name, ".epub")) {
-                    char full_path[512];
-                    snprintf(full_path, sizeof(full_path), "%s/%s", mount_path, dir->d_name);
-
-                    // miniz not available
-                    if (strstr(dir->d_name, ".epub")) {
-                        cJSON_AddStringToObject(file_obj, "title", dir->d_name);
-                        cJSON_AddStringToObject(file_obj, "author", "Unknown Author");
-                    } else {
-                        cJSON_AddStringToObject(file_obj, "title", dir->d_name);
-                        cJSON_AddStringToObject(file_obj, "author", "Unknown");
-                    }
+                    cJSON_AddStringToObject(file_obj, "title", dir->d_name);
+                    cJSON_AddStringToObject(file_obj, "author", "Unknown Author");
                 } else {
                     // For other file types, just use the filename
                     cJSON_AddStringToObject(file_obj, "title", dir->d_name);


### PR DESCRIPTION
💡 **What**:
1. Replaced multiple `for` loops utilizing `strncpy` with single `memmove` operations for array shifting in `main/audio_api.c`.
2. Removed redundant `strstr` checks and a wasted `snprintf` allocation/operation inside the `list_files_handler` `while` loop in `main/main.c`.

🎯 **Why**:
1. Manual string copying inside `for` loops to shift arrays is `O(N)` and wastes CPU cycles padding strings with zeros. `memmove` performs this block transfer instantly at a lower level.
2. The `list_files_handler` was allocating 512 bytes on the FreeRTOS task stack and running an expensive string formatting operation (`snprintf`) for *every* `.epub` file found on the SD card, but the resulting `full_path` variable was never actually used! Removing it saves stack space and significantly speeds up directory listing.

📊 **Impact**:
- Significantly faster array shifting for the Audio Radio queue.
- Faster TTFB (Time To First Byte) and lower task stack usage when querying `/list-files` on large library directories.

🔬 **Measurement**:
The improvements were verified via C code compilation tests and Playwright UI tests to ensure no regressions were introduced to the backend APIs.

---
*PR created automatically by Jules for task [796212670628205957](https://jules.google.com/task/796212670628205957) started by @LokiMetaSmith*