### PR TITLE
🎨 Palette: Add explanatory tooltips to disabled POST button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-29 - Add explanatory tooltips to disabled POST button
+**Learning:** Adding a native HTML `title` attribute to a disabled button provides a simple, accessible way to explain *why* the button is disabled without needing complex custom tooltip components.
+**Action:** When disabling interactive UI elements, always dynamically add a descriptive `title` attribute, and remember to remove it when the element is re-enabled.

--- a/main/web_assets/board.html
+++ b/main/web_assets/board.html
@@ -420,10 +420,16 @@ async function checkBoardStatus() {
     const btn    = document.getElementById('postBtn');
     if (d.full) {
       banner.style.display = 'block';
-      if (btn) btn.disabled = true;
+      if (btn) {
+        btn.disabled = true;
+        btn.title = "The board is currently full. Check back later.";
+      }
     } else {
       banner.style.display = 'none';
-      if (btn) btn.disabled = false;
+      if (btn) {
+        btn.disabled = false;
+        btn.removeAttribute('title');
+      }
     }
   } catch (e) {}
 }
@@ -607,6 +613,7 @@ async function doPost() {
   if (btn) {
     btn.disabled = true;
     btn.textContent = 'POSTING...';
+    btn.title = "Post is currently being submitted...";
   }
 
   localStorage.setItem('cn_name', n);
@@ -624,6 +631,7 @@ async function doPost() {
     if (btn) {
       btn.disabled = false;
       btn.textContent = 'POST';
+      btn.removeAttribute('title');
     }
   }
 


### PR DESCRIPTION
💡 What: Added dynamic `title` attributes to the `#postBtn` in `board.html` when it is disabled to explain why the user cannot interact with it (e.g., "The board is currently full" or "Post is currently being submitted...").
🎯 Why: Without an explanation, users may be confused as to why the POST button is disabled. Adding a tooltip provides immediate, context-aware feedback and improves the overall user experience.
📸 Before/After: Visual changes are not easily captured statically, but hovering over the dimmed POST button now reveals a native tooltip.
♿ Accessibility: Improved understanding of disabled states for mouse and screen reader users via the native HTML `title` attribute.

---
*PR created automatically by Jules for task [15539527990214340010](https://jules.google.com/task/15539527990214340010) started by @LokiMetaSmith*