### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS vulnerability from unverified cJSON types

### DIFF
--- a/main/bulletin_api.c
+++ b/main/bulletin_api.c
@@ -103,17 +103,17 @@ static esp_err_t board_post_handler(httpd_req_t *req) {
     cJSON *j_expiry = cJSON_GetObjectItem(json, "expiry");
 
     char author[25] = "neighbor";
-    if (j_author && j_author->valuestring) sanitize(j_author->valuestring, author, 25);
+    if (j_author && cJSON_IsString(j_author) && j_author->valuestring) sanitize(j_author->valuestring, author, 25);
     
     char type[16] = "Notice";
-    if (j_type && j_type->valuestring) {
+    if (j_type && cJSON_IsString(j_type) && j_type->valuestring) {
         if (strcmp(j_type->valuestring, "Offer") == 0 || strcmp(j_type->valuestring, "Need") == 0 || strcmp(j_type->valuestring, "Event") == 0) {
             strncpy(type, j_type->valuestring, 15);
         }
     }
 
     char text[301] = "";
-    if (j_text && j_text->valuestring) sanitize(j_text->valuestring, text, 301);
+    if (j_text && cJSON_IsString(j_text) && j_text->valuestring) sanitize(j_text->valuestring, text, 301);
 
     int expiry = 72;
     if (j_expiry && cJSON_IsNumber(j_expiry)) expiry = j_expiry->valueint;
@@ -156,7 +156,7 @@ static esp_err_t admin_auth_handler(httpd_req_t *req) {
     if (!json) { httpd_resp_send_500(req); return ESP_FAIL; }
 
     cJSON *j_key = cJSON_GetObjectItem(json, "key");
-    if (j_key && j_key->valuestring && bb_check_key(j_key->valuestring)) {
+    if (j_key && cJSON_IsString(j_key) && j_key->valuestring && bb_check_key(j_key->valuestring)) {
         char token[33];
         bb_generate_token(token);
         httpd_resp_send(req, token, strlen(token));

--- a/main/bulletin_board.c
+++ b/main/bulletin_board.c
@@ -47,15 +47,15 @@ void bb_load_identity(void) {
     cJSON *json = cJSON_Parse(string);
     if (json) {
         cJSON *item = cJSON_GetObjectItem(json, "name");
-        if (item && item->valuestring) strncpy(id_name, item->valuestring, sizeof(id_name)-1);
+        if (item && cJSON_IsString(item) && item->valuestring) strncpy(id_name, item->valuestring, sizeof(id_name)-1);
         item = cJSON_GetObjectItem(json, "icon");
-        if (item && item->valuestring) strncpy(id_icon, item->valuestring, sizeof(id_icon)-1);
+        if (item && cJSON_IsString(item) && item->valuestring) strncpy(id_icon, item->valuestring, sizeof(id_icon)-1);
         item = cJSON_GetObjectItem(json, "tagline");
-        if (item && item->valuestring) strncpy(id_tagline, item->valuestring, sizeof(id_tagline)-1);
+        if (item && cJSON_IsString(item) && item->valuestring) strncpy(id_tagline, item->valuestring, sizeof(id_tagline)-1);
         item = cJSON_GetObjectItem(json, "rules");
-        if (item && item->valuestring) strncpy(id_rules, item->valuestring, sizeof(id_rules)-1);
+        if (item && cJSON_IsString(item) && item->valuestring) strncpy(id_rules, item->valuestring, sizeof(id_rules)-1);
         item = cJSON_GetObjectItem(json, "footer");
-        if (item && item->valuestring) strncpy(id_footer, item->valuestring, sizeof(id_footer)-1);
+        if (item && cJSON_IsString(item) && item->valuestring) strncpy(id_footer, item->valuestring, sizeof(id_footer)-1);
         cJSON_Delete(json);
     }
     free(string);
@@ -93,7 +93,7 @@ void bb_load_admin_key(void) {
     cJSON *json = cJSON_Parse(string);
     if (json) {
         cJSON *item = cJSON_GetObjectItem(json, "key");
-        if (item && item->valuestring) strncpy(admin_key, item->valuestring, sizeof(admin_key)-1);
+        if (item && cJSON_IsString(item) && item->valuestring) strncpy(admin_key, item->valuestring, sizeof(admin_key)-1);
         cJSON_Delete(json);
     }
     free(string);
@@ -165,19 +165,19 @@ void bb_load_messages(void) {
             if (!item) continue;
             
             cJSON *cid = cJSON_GetObjectItem(item, "id");
-            msgs[msgCount].id = cid ? cid->valueint : nextMsgId;
+            msgs[msgCount].id = (cid && cJSON_IsNumber(cid)) ? cid->valueint : nextMsgId;
             
             cJSON *cauthor = cJSON_GetObjectItem(item, "author");
-            if (cauthor && cauthor->valuestring) strncpy(msgs[msgCount].author, cauthor->valuestring, sizeof(msgs[0].author)-1);
+            if (cauthor && cJSON_IsString(cauthor) && cauthor->valuestring) strncpy(msgs[msgCount].author, cauthor->valuestring, sizeof(msgs[0].author)-1);
             
             cJSON *ctype = cJSON_GetObjectItem(item, "type");
-            if (ctype && ctype->valuestring) strncpy(msgs[msgCount].type, ctype->valuestring, sizeof(msgs[0].type)-1);
+            if (ctype && cJSON_IsString(ctype) && ctype->valuestring) strncpy(msgs[msgCount].type, ctype->valuestring, sizeof(msgs[0].type)-1);
             
             cJSON *ctext = cJSON_GetObjectItem(item, "text");
-            if (ctext && ctext->valuestring) strncpy(msgs[msgCount].text, ctext->valuestring, sizeof(msgs[0].text)-1);
+            if (ctext && cJSON_IsString(ctext) && ctext->valuestring) strncpy(msgs[msgCount].text, ctext->valuestring, sizeof(msgs[0].text)-1);
             
             cJSON *cexp = cJSON_GetObjectItem(item, "expires");
-            msgs[msgCount].expires = cexp ? cexp->valuedouble : 0;
+            msgs[msgCount].expires = (cexp && cJSON_IsNumber(cexp)) ? cexp->valuedouble : 0;
             
             if (msgs[msgCount].id >= nextMsgId) nextMsgId = msgs[msgCount].id + 1;
             msgCount++;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing type checks when extracting variables from JSON payloads using cJSON. 
🎯 Impact: Denial of Service (DoS) vulnerability. Accessing `->valuestring` or `->valueint` directly on variables returned by `cJSON_GetObjectItem()` without verifying their types (`cJSON_IsString` or `cJSON_IsNumber`) can cause invalid memory access and crash the ESP32.
🔧 Fix: Add `cJSON_IsString` and `cJSON_IsNumber` checks across the `bulletin_api.c` and `bulletin_board.c` components when retrieving values.
✅ Verification: Ensured code changes align with cJSON usage standards. Verified compilation check steps logic.

---
*PR created automatically by Jules for task [17537126660303578339](https://jules.google.com/task/17537126660303578339) started by @LokiMetaSmith*