### PR TITLE
🎨 Palette: Dynamic List Item Buttons ARIA Labels

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,3 @@
-## 2024-07-29 - Add explanatory tooltips to disabled POST button
-**Learning:** Adding a native HTML `title` attribute to a disabled button provides a simple, accessible way to explain *why* the button is disabled without needing complex custom tooltip components.
-**Action:** When disabling interactive UI elements, always dynamically add a descriptive `title` attribute, and remember to remove it when the element is re-enabled.
+## 2024-05-24 - Dynamic List Item Buttons ARIA Labels
+**Learning:** When buttons like "Delete" or "Transfer" exist in dynamic Vue lists (v-for), screen readers announce generic identical names for all list items. Using dynamic :aria-label bindings with list item properties (file.title) provides essential context.
+**Action:** Always bind :aria-label to list item specific data when buttons perform actions on dynamically generated list entries.

--- a/main/web_assets/index.html
+++ b/main/web_assets/index.html
@@ -77,10 +77,10 @@
                             <div class="progress-container" v-if="transfer.active && transfer.filename === file.name">
                                 <div class="progress-bar" :style="{ width: transfer.progress + '%' }"></div>
                             </div>
-                            <button @click="transferToEReader(file.name)" :disabled="!isEReaderConnected || transfer.active" :title="transfer.active ? 'A transfer is currently in progress' : (!isEReaderConnected ? 'Connect an E-Reader to transfer books' : 'Transfer to E-Reader')">Transfer to E-Reader</button>
-                            <a class="sleep-btn" style="text-decoration: none;" v-if="file.name.toLowerCase().endsWith('.epub')" :href="'/viewer.html?file=' + encodeURIComponent(file.name) + '&source=sd'">Read</a>
-                            <button v-if="isAdmin" @click="deleteFile(file.name, 'sd')" class="btn danger" style="background-color: #c94b4b; color: white;">Delete</button>
-                            <button v-if="transfer.active && transfer.filename === file.name" @click="cancelTransfer" class="cancel-btn">Cancel</button>
+                            <button @click="transferToEReader(file.name)" :disabled="!isEReaderConnected || transfer.active" :title="transfer.active ? 'A transfer is currently in progress' : (!isEReaderConnected ? 'Connect an E-Reader to transfer books' : 'Transfer to E-Reader')" :aria-label="'Transfer ' + file.title + ' to E-Reader'">Transfer to E-Reader</button>
+                            <a class="sleep-btn" style="text-decoration: none;" v-if="file.name.toLowerCase().endsWith('.epub')" :href="'/viewer.html?file=' + encodeURIComponent(file.name) + '&source=sd'" :aria-label="'Read ' + file.title">Read</a>
+                            <button v-if="isAdmin" @click="deleteFile(file.name, 'sd')" class="btn danger" style="background-color: #c94b4b; color: white;" :aria-label="'Delete ' + file.title">Delete</button>
+                            <button v-if="transfer.active && transfer.filename === file.name" @click="cancelTransfer" class="cancel-btn" :aria-label="'Cancel transfer for ' + file.title">Cancel</button>
                         </div>
                     </li>
                 </ul>
@@ -103,9 +103,9 @@
                                 <div class="progress-container" v-if="transfer.active && transfer.filename === file.name">
                                     <div class="progress-bar" :style="{ width: transfer.progress + '%' }"></div>
                                 </div>
-                                <button @click="transferToLibrary(file.name)" :disabled="transfer.active" :title="transfer.active ? 'A transfer is currently in progress' : 'Transfer to Library'">Transfer to Library</button>
-                                <button v-if="isAdmin" @click="deleteFile(file.name, 'usb')" class="btn danger" style="background-color: #c94b4b; color: white;">Delete</button>
-                                <button v-if="transfer.active && transfer.filename === file.name" @click="cancelTransfer" class="cancel-btn">Cancel</button>
+                                <button @click="transferToLibrary(file.name)" :disabled="transfer.active" :title="transfer.active ? 'A transfer is currently in progress' : 'Transfer to Library'" :aria-label="'Transfer ' + file.title + ' to Library'">Transfer to Library</button>
+                                <button v-if="isAdmin" @click="deleteFile(file.name, 'usb')" class="btn danger" style="background-color: #c94b4b; color: white;" :aria-label="'Delete ' + file.title">Delete</button>
+                                <button v-if="transfer.active && transfer.filename === file.name" @click="cancelTransfer" class="cancel-btn" :aria-label="'Cancel transfer for ' + file.title">Cancel</button>
                             </div>
                         </li>
                     </ul>

--- a/test_ux.py
+++ b/test_ux.py
@@ -9,6 +9,12 @@ def test_ux():
     assert "Upload in progress..." in content, "Missing title tooltip"
     assert "Connect an E-Reader to transfer books" in content, "Missing title tooltip"
 
+    assert ":aria-label=\"'Transfer ' + file.title + ' to E-Reader'\"" in content, "Missing Transfer aria-label"
+    assert ":aria-label=\"'Transfer ' + file.title + ' to Library'\"" in content, "Missing Transfer to Library aria-label"
+    assert ":aria-label=\"'Read ' + file.title\"" in content, "Missing Read aria-label"
+    assert ":aria-label=\"'Delete ' + file.title\"" in content, "Missing Delete aria-label"
+    assert ":aria-label=\"'Cancel transfer for ' + file.title\"" in content, "Missing Cancel transfer aria-label"
+
     with open('main/web_assets/style.css', 'r') as f:
         css_content = f.read()
 


### PR DESCRIPTION
💡 What: Added dynamic `aria-label` bindings (`:aria-label`) to icon-like buttons ("Transfer", "Read", "Delete", "Cancel") inside the dynamic `v-for` lists in `index.html`.
🎯 Why: Without these labels, screen readers announce generic, identical names for all list items (e.g., "Delete, Delete, Delete").
📸 Before/After: Visuals remain unchanged. Screen readers now read "Delete My Book" instead of "Delete".
♿ Accessibility: Improved screen reader navigation context inside dynamic lists.

---
*PR created automatically by Jules for task [9791881030451527397](https://jules.google.com/task/9791881030451527397) started by @LokiMetaSmith*