### PR TITLE
⚡ Bolt: Add Cache-Control headers for static assets

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -29,3 +29,6 @@
 ## 2024-05-19 - O(1) File Extension Checking
 **Learning:** In C, `strstr(filename, ".ext")` performs an O(N*M) sequential substring search across the entire string, which is slow for directories with many files and causes bugs by incorrectly matching substrings in the middle of a filename (e.g., `book.epub.bak`).
 **Action:** Always use `strrchr(filename, '.')` to jump directly to the extension and `strcasecmp` to check it in O(1) time for file validation.
+## 2024-10-24 - Add Cache-Control for static assets
+**Learning:** ESP32 web servers suffer significantly when repeatedly serving large static assets (like `vue.global.js` at 164KB) because the device's CPU, SPIFFS read speed, and network stack are heavily constrained. Browsers will re-request these files on every navigation without an explicit Cache-Control header.
+**Action:** Always include a `Cache-Control` header (e.g. `public, max-age=31536000`) for large static dependencies in embedded web servers to allow the browser to skip the network request entirely, drastically improving page load times and reducing server load.

--- a/main/main.c
+++ b/main/main.c
@@ -710,8 +710,14 @@ static esp_err_t static_file_handler(httpd_req_t *req) {
         if (strcasecmp(ext, ".html") == 0) type = "text/html";
         else if (strcasecmp(ext, ".css") == 0) type = "text/css";
         else if (strcasecmp(ext, ".js") == 0) type = "application/javascript";
+        else if (strcasecmp(ext, ".ico") == 0) type = "image/x-icon";
     }
     httpd_resp_set_type(req, type);
+
+    // Add Cache-Control for static assets
+    if (ext && (strcasecmp(ext, ".css") == 0 || strcasecmp(ext, ".js") == 0 || strcasecmp(ext, ".ico") == 0)) {
+        httpd_resp_set_hdr(req, "Cache-Control", "public, max-age=31536000, immutable");
+    }
 
     // Open and send file
     FILE *fd = fopen(filepath, "r");


### PR DESCRIPTION
**💡 What:** Added a `Cache-Control: public, max-age=31536000, immutable` HTTP header to `.css`, `.js`, and `.ico` files served by the `static_file_handler`.

**🎯 Why:** ESP32 web servers suffer significantly when repeatedly serving large static assets (like `vue.global.js` at 164KB) because the device's CPU, SPIFFS read speed, and network stack are heavily constrained. Browsers will re-request these files on every navigation without an explicit `Cache-Control` header. 

**📊 Impact:** Drastically reduces server load and connection pool exhaustion by allowing the browser to serve these static files directly from local disk cache, greatly improving TTFB (Time to First Byte) on page navigations. 

**🔬 Measurement:** Verified by looking at the network tab in the browser dev tools. After the first load, subsequent requests to these files will show `(disk cache)` or `(memory cache)` instead of hitting the ESP32.

---
*PR created automatically by Jules for task [9778479596165355510](https://jules.google.com/task/9778479596165355510) started by @LokiMetaSmith*