### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to audio controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Dynamic List Item Buttons ARIA Labels
 **Learning:** When buttons like "Delete" or "Transfer" exist in dynamic Vue lists (v-for), screen readers announce generic identical names for all list items. Using dynamic :aria-label bindings with list item properties (file.title) provides essential context.
 **Action:** Always bind :aria-label to list item specific data when buttons perform actions on dynamically generated list entries.
+## 2024-07-02 - Audio Player Buttons ARIA Labels
+**Learning:** Icon-only or context-dependent buttons within dynamic lists and media players (like "Remove", "Add to Queue", or "Skip Track") can lack clear context for screen reader users if relying solely on generic text or visual placement. Using Vue's `:aria-label` binding allows interpolating current state or list item properties (like the current track name or list item title) to create highly descriptive, accessible labels.
+**Action:** Always add dynamic `:aria-label` bindings that incorporate specific state variables (e.g., `currentTrack`, `file.title`) when implementing controls for media players or dynamic item lists.

--- a/main/web_assets/audio.html
+++ b/main/web_assets/audio.html
@@ -50,7 +50,7 @@
                     <audio ref="audioPlayer" controls @play="onPlay" @pause="onPause" @seeked="onSeeked" @ended="onEnded">
                         Your browser does not support the audio element.
                     </audio>
-                    <button v-if="isDriver" @click="skipTrack" style="margin-top:10px;">Skip Track</button>
+                    <button v-if="isDriver" @click="skipTrack" :aria-label="'Skip ' + currentTrack" style="margin-top:10px;">Skip Track</button>
                 </div>
                 <div v-else>
                     <p style="color: #8a7b6c; font-style: italic;">Nothing is currently playing. Add a track to the queue!</p>
@@ -66,7 +66,7 @@
                     <div v-else>
                         <div v-for="(track, index) in queue" :key="index" class="queue-item">
                             <span>{{ index + 1 }}. {{ track }}</span>
-                            <button v-if="isAdmin" @click="removeFromQueue(index)" class="btn-small cancel-btn">Remove</button>
+                            <button v-if="isAdmin" @click="removeFromQueue(index)" :aria-label="'Remove ' + track + ' from queue'" class="btn-small cancel-btn">Remove</button>
                         </div>
                     </div>
                 </div>
@@ -79,7 +79,7 @@
                                 <span class="file-title">{{ file.title || file.name }}</span>
                             </div>
                             <div class="transfer-controls">
-                                <button @click="addToQueue(file.name)">Add to Queue</button>
+                                <button @click="addToQueue(file.name)" :aria-label="'Add ' + (file.title || file.name) + ' to queue'">Add to Queue</button>
                             </div>
                         </li>
                     </ul>

--- a/test_ux.py
+++ b/test_ux.py
@@ -15,6 +15,13 @@ def test_ux():
     assert ":aria-label=\"'Delete ' + file.title\"" in content, "Missing Delete aria-label"
     assert ":aria-label=\"'Cancel transfer for ' + file.title\"" in content, "Missing Cancel transfer aria-label"
 
+    with open('main/web_assets/audio.html', 'r') as f:
+        audio_content = f.read()
+
+    assert ":aria-label=\"'Remove ' + track + ' from queue'\"" in audio_content, "Missing Remove from queue aria-label"
+    assert ":aria-label=\"'Add ' + (file.title || file.name) + ' to queue'\"" in audio_content, "Missing Add to queue aria-label"
+    assert ":aria-label=\"'Skip ' + currentTrack\"" in audio_content, "Missing Skip Track aria-label"
+
     with open('main/web_assets/style.css', 'r') as f:
         css_content = f.read()
 


### PR DESCRIPTION
💡 **What:** Added dynamic `:aria-label` attributes to the "Skip Track", "Remove", and "Add to Queue" buttons in `audio.html`.
🎯 **Why:** To provide essential context to screen reader users navigating dynamic lists and media controls. Instead of generic "Remove" announcements, users will hear specific context like "Remove song1.mp3 from queue" or "Skip [current track name]".
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Significantly improves screen reader experience for the audio radio player by leveraging Vue.js dynamic bindings to construct context-aware accessible names for interactive elements. Tests have been updated to ensure these labels remain.

---
*PR created automatically by Jules for task [9847487590597299206](https://jules.google.com/task/9847487590597299206) started by @LokiMetaSmith*