### PR TITLE
🎨 Palette: [UX improvement] Improve Category label a11y on Board

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,3 @@
-## 2024-05-24 - Add Focus Visible Styles for Keyboard Navigation
-**Learning:** The application lacked clear focus indicators for keyboard users, making navigation difficult for those relying on assistive technologies or keyboards. The `:focus-visible` pseudo-class allows adding strong visual indicators without affecting mouse users.
-**Action:** Added global `:focus-visible` styles to interactive elements in `style.css` using the project's accent color to ensure a consistent and accessible keyboard navigation experience.
+## 2024-07-04 - [Board Category Accessibility]
+**Learning:** When using custom button groups instead of standard `<select>` or radio buttons for form inputs (like the Category selector on the board), screen readers lose the context that the label applies to the entire group of buttons.
+**Action:** Always wrap custom button groups in an element with `role="group"` and use `aria-labelledby` pointing to the ID of the visual label to maintain accessibility context.

--- a/main/web_assets/board.html
+++ b/main/web_assets/board.html
@@ -350,8 +350,8 @@ body {
     </div>
 
     <div class="field field-cat">
-      <label>Category</label>
-      <div class="cat-btns">
+      <label id="catLabel">Category</label>
+      <div class="cat-btns" role="group" aria-labelledby="catLabel">
         <button class="cat-btn active-Notice" aria-pressed="true" onclick="setType('Notice',this)">📌 Notice</button>
         <button class="cat-btn" aria-pressed="false" onclick="setType('Offer', this)">🌱 Offer</button>
         <button class="cat-btn" aria-pressed="false" onclick="setType('Need',  this)">🤝 Need</button>


### PR DESCRIPTION
**What:**
Added proper ARIA attributes to connect the "Category" visual label with the group of custom category filter buttons on the Community Board.

**Why:**
Screen readers lose the context that the "Category" label applies to the entire group of buttons since they aren't native `<select>` or radio button form inputs.

**Before/After:**
- Before: Screen reader simply announced individual button labels ("Notice", "Offer") without group context.
- After: Screen reader announces "Category group" when entering the section, giving users context for what the buttons control.

**Accessibility:**
Added `id="catLabel"` to the label and wrapped the buttons in a container with `role="group" aria-labelledby="catLabel"`.

---
*PR created automatically by Jules for task [2035517782192787627](https://jules.google.com/task/2035517782192787627) started by @LokiMetaSmith*