### PR TITLE
⚡ Bolt: Combine bulletin board API endpoints to fix fetch waterfall latency

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -44,3 +44,7 @@
 **Learning:** In ESP-IDF web servers, using parallel fetches (`Promise.all`) or sequential fetch chains to multiple endpoints exhausts the connection limit, causing `no slots left for registering handler` or high latency. Previously, `list-files?type=sd` and `list-files?type=usb` were fetched sequentially to avoid the parallel limitation, but this introduced "waterfall" latency on the frontend.
 **Action:** When a frontend needs data from multiple backend sources on load, combine them into a single consolidated endpoint (e.g. `type=all`) that streams a combined JSON response using `httpd_resp_send_chunk`. This solves both the connection exhaustion issue and the frontend fetch latency penalty.
 
+
+## 2024-11-23 - [Combine bulletin board API endpoints to fix fetch waterfall]
+**Learning:** Sequential fetches in JavaScript (`await fetch(a); await fetch(b); await fetch(c);`) resolve the connection pool exhaustion issues on ESP-IDF web servers, but introduce a severe "fetch waterfall" latency penalty on the frontend, drastically slowing down page loads and updates.
+**Action:** Always combine related frontend data requests (like info, status, and messages for a bulletin board) into a single consolidated backend endpoint (e.g. `/board/all`) that returns a combined JSON payload.

--- a/main/bulletin_api.c
+++ b/main/bulletin_api.c
@@ -48,6 +48,47 @@ static esp_err_t board_info_handler(httpd_req_t *req) {
     return ESP_OK;
 }
 
+
+static esp_err_t board_all_handler(httpd_req_t *req) {
+    cJSON *doc = cJSON_CreateObject();
+
+    cJSON *status_obj = cJSON_CreateObject();
+    cJSON_AddBoolToObject(status_obj, "full", msgCount >= MAX_MSGS);
+    cJSON_AddItemToObject(doc, "status", status_obj);
+
+    cJSON *info_obj = cJSON_CreateObject();
+    cJSON_AddStringToObject(info_obj, "name", id_name);
+    cJSON_AddStringToObject(info_obj, "icon", id_icon);
+    cJSON_AddStringToObject(info_obj, "tagline", id_tagline);
+    cJSON_AddStringToObject(info_obj, "rules", id_rules);
+    cJSON_AddStringToObject(info_obj, "footer", id_footer);
+    char uptime_str[32];
+    snprintf(uptime_str, sizeof(uptime_str), "Uptime: %lu m", (unsigned long)(esp_timer_get_time() / 60000000ULL));
+    cJSON_AddStringToObject(info_obj, "uptime", uptime_str);
+    cJSON_AddItemToObject(doc, "info", info_obj);
+
+    cJSON *msgs_arr = cJSON_CreateArray();
+    unsigned long now = nowSecs();
+    for (int i = 0; i < msgCount; i++) {
+        if (msgs[i].expires < now) continue;
+        cJSON *obj = cJSON_CreateObject();
+        cJSON_AddNumberToObject(obj, "id", msgs[i].id);
+        cJSON_AddStringToObject(obj, "author", msgs[i].author);
+        cJSON_AddStringToObject(obj, "type", msgs[i].type);
+        cJSON_AddStringToObject(obj, "text", msgs[i].text);
+        cJSON_AddNumberToObject(obj, "expires", msgs[i].expires);
+        cJSON_AddItemToArray(msgs_arr, obj);
+    }
+    cJSON_AddItemToObject(doc, "messages", msgs_arr);
+
+    char *json_str = cJSON_PrintUnformatted(doc);
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_send(req, json_str, strlen(json_str));
+    free(json_str);
+    cJSON_Delete(doc);
+    return ESP_OK;
+}
+
 static esp_err_t board_messages_handler(httpd_req_t *req) {
     cJSON *doc = cJSON_CreateArray();
     unsigned long now = nowSecs();
@@ -337,6 +378,10 @@ void register_bulletin_api_handlers(httpd_handle_t server) {
 
     httpd_uri_t msgs_uri = { .uri = "/board/messages", .method = HTTP_GET, .handler = board_messages_handler, .user_ctx = NULL };
     httpd_register_uri_handler(server, &msgs_uri);
+
+    httpd_uri_t all_uri = { .uri = "/board/all", .method = HTTP_GET, .handler = board_all_handler, .user_ctx = NULL };
+    httpd_register_uri_handler(server, &all_uri);
+
 
     httpd_uri_t post_uri = { .uri = "/board/post", .method = HTTP_POST, .handler = board_post_handler, .user_ctx = NULL };
     httpd_register_uri_handler(server, &post_uri);

--- a/main/web_assets/board.html
+++ b/main/web_assets/board.html
@@ -406,26 +406,22 @@ body {
 
 <script>
 // First thing's first:
-async function checkBoardStatus() {
-  try {
-    const r = await fetch('/board/api/status');
-    const d = await r.json();
-    const banner = document.getElementById('fullBanner');
-    const btn    = document.getElementById('postBtn');
-    if (d.full) {
-      banner.style.display = 'block';
-      if (btn) {
-        btn.disabled = true;
-        btn.title = "The board is currently full. Check back later.";
-      }
-    } else {
-      banner.style.display = 'none';
-      if (btn) {
-        btn.disabled = false;
-        btn.removeAttribute('title');
-      }
+function updateBoardStatus(d) {
+  const banner = document.getElementById('fullBanner');
+  const btn    = document.getElementById('postBtn');
+  if (d.full) {
+    banner.style.display = 'block';
+    if (btn) {
+      btn.disabled = true;
+      btn.title = "The board is currently full. Check back later.";
     }
-  } catch (e) {}
+  } else {
+    banner.style.display = 'none';
+    if (btn) {
+      btn.disabled = false;
+      btn.removeAttribute('title');
+    }
+  }
 }
 // ── XSS-safe escaping ──────────────────────────
 function esc(s) {
@@ -551,16 +547,7 @@ async function loadSystemStatus() {
     console.error("Failed to load status", e);
   }
 }
-async function load() {
-  try {
-    await checkBoardStatus();
-    const r  = await fetch('/board/messages');
-    lastData = await r.json();
-    render(lastData);
-  } catch (_) {
-    console.error('Connection lost');
-  }
-}
+
 
 function render(data) {
   let filtered = activeFilter ? data.filter(m => m.type === activeFilter) : data;
@@ -598,7 +585,6 @@ function render(data) {
 
 // ── Post ───────────────────────────────────────
 async function doPost() {
-  await checkBoardStatus();
   const n = document.getElementById('nameIn').value.trim() || 'neighbor';
   const t = document.getElementById('msgIn').value.trim();
   if (!t) return;
@@ -629,28 +615,35 @@ async function doPost() {
     }
   }
 
-  await load();
-  await loadSystemStatus();
+  await runPolling();
 }
 
 // ── Board info ─────────────────────────────────
-async function loadInfo() {
-  try {
-    const r = await fetch('/board/info');
-    const d = await r.json();
-    document.getElementById('boardTitle').textContent   = d.icon + '  ' + d.name;
-    document.getElementById('boardTagline').textContent = d.tagline;
-    document.getElementById('boardRules').textContent   = d.rules;
-    document.getElementById('boardFooter').textContent  = d.footer;
-    document.getElementById('uptimeDisplay').textContent = d.uptime;
-  } catch (e) {}
-}
-
 // ⚡ Bolt: Fetch board data sequentially to prevent connection pool exhaustion
+// Board data is fetched from a single combined endpoint to prevent fetch waterfall latency
 async function runPolling() {
-  await loadInfo();
+  try {
+    const r = await fetch('/board/all');
+    const d = await r.json();
+
+    // update info
+    document.getElementById('boardTitle').textContent   = d.info.icon + '  ' + d.info.name;
+    document.getElementById('boardTagline').textContent = d.info.tagline;
+    document.getElementById('boardRules').textContent   = d.info.rules;
+    document.getElementById('boardFooter').textContent  = d.info.footer;
+    document.getElementById('uptimeDisplay').textContent = d.info.uptime;
+
+    // update status
+    updateBoardStatus(d.status);
+
+    // update messages
+    lastData = d.messages;
+    render(lastData);
+  } catch (e) {
+    console.error('Failed to load board data', e);
+  }
+
   await loadSystemStatus();
-  await load();
 }
 
 runPolling();


### PR DESCRIPTION
### 💡 What
Combined multiple sequential fetch requests (`/board/info`, `/board/api/status`, `/board/messages`) from the bulletin board frontend into a single `/board/all` backend endpoint.

### 🎯 Why
ESP-IDF web servers suffer from connection pool exhaustion when receiving concurrent `Promise.all` requests. The previous workaround was to fetch these endpoints sequentially. However, doing so introduced a severe "fetch waterfall" latency penalty that drastically slowed down page loading and data polling.

### 📊 Impact
Eliminates 2 out of 3 HTTP requests required to refresh the bulletin board state. Reduces total rendering latency and drastically lowers overhead on the ESP32 `httpd` thread pool.

### 🔬 Measurement
Verify the reduction in network requests via browser DevTools (Network tab) when loading or polling `board.html`.

---
*PR created automatically by Jules for task [12597463630433677722](https://jules.google.com/task/12597463630433677722) started by @LokiMetaSmith*