### PR TITLE
Fix floating unconnected lip in OpenSCAD enclosure template

### DIFF
--- a/hardware/cad/enclosure_template.scad
+++ b/hardware/cad/enclosure_template.scad
@@ -82,7 +82,7 @@ module final_assembly() {
     book_box();
 
     // 2. The cover, placed on top of the box
-    translate([-cover_overhang, -cover_overhang, outer_height]) {
+    translate([-cover_overhang, -cover_overhang, outer_height - 1]) {
         cover();
     }
 
@@ -90,7 +90,7 @@ module final_assembly() {
     if (litho_enabled) {
         // You will likely need to adjust the translation and rotation
         // to get the perfect fit for your specific lithophane.
-        translate([cover_overhang, -cover_overhang, outer_height + cover_height]) {
+        translate([cover_overhang, -cover_overhang, outer_height + cover_height - 1]) {
             // Rotate the lithophane to be flat on the cover
             rotate([90, 0, 90]) {
                 import(bent_litho_stl_path);


### PR DESCRIPTION
Fixed the issue where the cover was not making contact with the box in the OpenSCAD assembly view. I moved the cover and the lithophane down by 1mm to ensure a solid overlap. I also removed an accidental `build_output.log` file created during testing.

---
*PR created automatically by Jules for task [12077344706839356019](https://jules.google.com/task/12077344706839356019) started by @LokiMetaSmith*