### PR TITLE
🎨 Palette: Add immediate visual feedback to admin login button

### DIFF
--- a/main/web_assets/admin.html
+++ b/main/web_assets/admin.html
@@ -209,7 +209,7 @@ textarea.restore-area:focus { border-color: var(--accent-dark); }
   <h2>Admin Access</h2>
   <label for="keyIn">Admin Access Key</label>
   <input type="password" id="keyIn" autocomplete="off">
-  <button onclick="tryLogin()">Unlock 🔑</button>
+  <button id="loginBtn" onclick="tryLogin()">Unlock 🔑</button>
   <div class="error" id="gateErr" aria-live="assertive"></div>
 </div>
 
@@ -360,6 +360,12 @@ function tryLogin() {
   const val = document.getElementById('keyIn').value;
   if (!val) return;
 
+  const btn = document.getElementById('loginBtn');
+  if (btn) {
+    btn.disabled = true;
+    btn.textContent = 'Unlocking... 🔑';
+  }
+
   fetch('/board/admin/auth', {
     method: 'POST',
     body: JSON.stringify({ key: val })
@@ -374,9 +380,17 @@ function tryLogin() {
     document.getElementById('gate').style.display  = 'none';
     document.getElementById('panel').style.display = 'block';
     loadAdminData();
+    if (btn) {
+      btn.disabled = false;
+      btn.textContent = 'Unlock 🔑';
+    }
   })
   .catch(() => {
     document.getElementById('gateErr').textContent = 'Incorrect key.';
+    if (btn) {
+      btn.disabled = false;
+      btn.textContent = 'Unlock 🔑';
+    }
   });
 }
 document.getElementById('keyIn').addEventListener('keydown', e => {


### PR DESCRIPTION
🎨 **Palette: Add loading state to Admin Login button**

💡 **What:** 
Added a disabled/loading state to the "Unlock 🔑" button in `admin.html` during the asynchronous login `fetch()` request. It now shows "Unlocking... 🔑" and becomes un-clickable until the request finishes.

🎯 **Why:** 
Vanilla JS frontends lack default form-submission loading states. Without immediate visual feedback, users experiencing latency may double-click the login button, leading to multiple API calls and a confusing perceived lag. This small addition makes the interaction feel instantly responsive and prevents duplicate submissions.

📸 **Before/After:**
*(See visual validation screenshot)*

♿ **Accessibility:**
While primarily an interaction fix, disabling the button explicitly communicates the pending state to assistive technologies that monitor element states.

---
*PR created automatically by Jules for task [14230688102085226170](https://jules.google.com/task/14230688102085226170) started by @LokiMetaSmith*