### PR TITLE
🛡️ Sentinel: [HIGH] Fix Out-of-Bounds Write vulnerabilities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** The `/about.html` page fetches the content of `about.txt` (a user-uploadable file if public uploads are enabled) and inserts it directly into the DOM using `innerHTML` without HTML entity encoding, enabling Stored XSS.
 **Learning:** Any content fetched dynamically from files that could potentially be modified by users (like texts, configs, or descriptions) MUST be treated as untrusted input. Directly using `innerHTML` with unsanitized file content creates a severe XSS risk.
 **Prevention:** Always sanitize/escape text fetched from external or user-modifiable files before inserting it into the DOM using `innerHTML`, or prefer using `textContent` instead when HTML rendering is not strictly required.
+
+## 2025-01-20 - Prevent Out-of-Bounds Write via Null Terminator on HTTP Payload
+**Vulnerability:** HTTP handlers were reading request payloads up to `remaining` bytes into buffers allocated exactly as `malloc(remaining)` or fixed size (e.g., `malloc(1024)` for max 1024 length), and then immediately appending a null terminator `buf[ret] = '\0'`. If `ret` reached the max buffer size, this caused an Out-of-Bounds write of one byte.
+**Learning:** When using `httpd_req_recv` to receive HTTP payloads and converting them into null-terminated C-strings, the buffer must explicitly allocate one extra byte (`+ 1`) exclusively for the null terminator. Checking `remaining >= MAX_SIZE` and allocating `MAX_SIZE` is insufficient if the receive loop reads up to `MAX_SIZE` and then sets `buf[MAX_SIZE] = '\0'`.
+**Prevention:** Always allocate `expected_max_length + 1` bytes when null-terminating dynamic buffers after a socket read.

--- a/main/bulletin_api.c
+++ b/main/bulletin_api.c
@@ -118,7 +118,8 @@ static esp_err_t board_post_handler(httpd_req_t *req) {
         return ESP_FAIL;
     }
 
-    char *buf = (char *)malloc(1024);
+    // Allocate an extra byte for the null terminator to prevent out-of-bounds write
+    char *buf = (char *)malloc(1025);
     if (!buf) {
         httpd_resp_send_500(req);
         return ESP_FAIL;
@@ -179,7 +180,8 @@ static esp_err_t admin_auth_handler(httpd_req_t *req) {
         return ESP_FAIL;
     }
 
-    char *buf = (char *)malloc(256);
+    // Allocate an extra byte for the null terminator to prevent out-of-bounds write
+    char *buf = (char *)malloc(257);
     if (!buf) {
         httpd_resp_send_500(req);
         return ESP_FAIL;


### PR DESCRIPTION
When receiving HTTP payloads in `board_post_handler` and `admin_auth_handler`, the code dynamically allocates exactly the expected maximum payload length (e.g., `1024` or `256` bytes). It then reads up to that amount of data into the buffer using `httpd_req_recv` and immediately sets `buf[ret] = '\0'`. If `ret` equals the allocated buffer size, this causes a single-byte out-of-bounds write past the end of the heap allocation.

To safely accommodate the null terminator, the buffer allocations have been increased by 1 byte (e.g., `malloc(1025)` and `malloc(257)`).

Other static buffers (e.g. `char content[256]`) used with `httpd_req_recv` were analyzed and confirmed safe, as they already read up to `sizeof(content) - 1`.

---
*PR created automatically by Jules for task [9563971728969332514](https://jules.google.com/task/9563971728969332514) started by @LokiMetaSmith*