### PR TITLE
⚡ Bolt: Convert admin UI concurrent fetches to sequential awaits

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -51,3 +51,7 @@
 ## 2024-11-23 - [Replace O(N) array shifts with memmove in C backend]
 **Learning:** Manually shifting array structures using `for` loops causes unnecessary overhead and is O(N).
 **Action:** Replace these `for` loops with `memmove` for safe and heavily optimized memory block copies.
+
+## 2024-11-23 - [Incomplete Rollout of Await in Async Refactor]
+**Learning:** When converting a function that uses a `.then()` chain into an `async/await` sequence, if that function is called within another `async` function and preceded by `await`, it must either be marked as `async` itself (and `await` its internal Promises) or return the Promise explicitly. Otherwise, it implicitly returns `undefined`, the `await` resolves immediately, and the underlying fetches execute concurrently instead of sequentially, defeating the purpose of the refactor.
+**Action:** When refactoring concurrent fetches into sequential awaits, ensure that all functions in the call stack are properly awaited and that intermediate functions are correctly converted to `async` (or return their Promises) so the `await` accurately blocks execution until the network request completes.

--- a/main/web_assets/admin.html
+++ b/main/web_assets/admin.html
@@ -340,19 +340,20 @@ window.addEventListener('DOMContentLoaded', () => {
     .catch(e => console.log('Hardware auth not present.'));
 });
 
-function loadAdminData() {
+async function loadAdminData() {
   // Load identity info
-  apiFetch(api('/board/admin/identity/get'))
-    .then(r => r.json())
-    .then(d => {
-      document.getElementById('idName').value = d.name || '';
-      document.getElementById('idIcon').value = d.icon || '';
-      document.getElementById('idTagline').value = d.tagline || '';
-      document.getElementById('idRules').value = d.rules || '';
-      document.getElementById('idFooter').value = d.footer || '';
-    });
-  loadPostList();
-  loadUploadSettings();
+  const r = await apiFetch(api('/board/admin/identity/get'));
+  const d = await r.json();
+  document.getElementById('idName').value = d.name || '';
+  document.getElementById('idIcon').value = d.icon || '';
+  document.getElementById('idTagline').value = d.tagline || '';
+  document.getElementById('idRules').value = d.rules || '';
+  document.getElementById('idFooter').value = d.footer || '';
+
+  // ⚡ Bolt: Await these to execute sequentially rather than concurrently
+  // to avoid exhausting the ESP-IDF connection pool.
+  await loadPostList();
+  await loadUploadSettings();
 }
 
 // ── Gate ────────────────────────────────────────────────────────────────────
@@ -423,12 +424,10 @@ function fb(id, msg) {
 }
 
 // ── Upload Settings ───────────────────────────────────────────────────────────
-function loadUploadSettings() {
-  fetch('/status')
-    .then(r => r.json())
-    .then(d => {
-      document.getElementById('publicUploadsCheck').checked = d.allow_public_uploads;
-    });
+async function loadUploadSettings() {
+  const r = await fetch('/status');
+  const d = await r.json();
+  document.getElementById('publicUploadsCheck').checked = d.allow_public_uploads;
 }
 
 function doSetPublicUploads() {


### PR DESCRIPTION
⚡ Bolt: Convert admin UI concurrent fetches to sequential awaits

💡 What: Modified `loadAdminData` and `loadUploadSettings` in `admin.html` to execute fetches sequentially using `await` instead of running concurrently. 

🎯 Why: Resolves a performance bottleneck where concurrent fetches trigger multiple HTTP handlers simultaneously on the ESP-IDF backend, exhausting the web server's connection pool.

📊 Impact: Reduces peak concurrent API requests on the admin page from 3 to 1, significantly improving reliability and backend responsiveness, at the cost of a minor acceptable latency penalty for admin users.

🔬 Measurement: Verify network timeline in browser DevTools on `/admin.html` to confirm requests are made one after another rather than in parallel.

---
*PR created automatically by Jules for task [15838963181927517864](https://jules.google.com/task/15838963181927517864) started by @LokiMetaSmith*