### PR TITLE
🎨 Palette: [UX improvement] Add contextual aria-labels and loading states to admin post deletion

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -22,3 +22,6 @@
 ## 2024-05-24 - Dynamic Disabled State Explanations with Keyboard Hints
 **Learning:** Adding static aria-labels and static titles to buttons isn't enough when their state changes (e.g. from disabled to enabled). Users need to know *why* a button is disabled, and screen readers need an aria-label. Furthermore, when the button is enabled, replacing the tooltip with keyboard shortcut hints greatly improves usability without cluttering the UI.
 **Action:** When creating interactive viewer-like experiences, provide a default `title` explaining the loading/disabled state along with a static `aria-label`. Then, dynamically update the `title` attribute via JavaScript to show keyboard shortcuts once the state becomes active.
+## 2024-11-21 - Passing element context in vanilla JS lists
+**Learning:** When rendering dynamic lists with string interpolation in vanilla JS (like in `admin.html`), it can be tricky to grab the exact button element later to apply loading states, especially if the button lacks a unique ID.
+**Action:** When adding inline onclick handlers in template literals (e.g., `onclick="deletePost(${id}, this)"`), pass `this` to give the function a direct reference to the clicked element, making it easy to toggle disabled states and text content immediately.

--- a/main/web_assets/admin.html
+++ b/main/web_assets/admin.html
@@ -517,7 +517,7 @@ async function loadPostList() {
     <div class="post-row-meta">${esc(m.type)} · ${esc(m.author)} · ${timeLeftShort(m.expires)} left</div>
     <div class="post-row-text">${esc(m.text)}</div>
   </div>
-  <button class="btn danger" onclick="deletePost(${m.id})">Delete</button>
+  <button class="btn danger" onclick="deletePost(${m.id}, this)" aria-label="Delete post by ${esc(m.author)}">Delete</button>
 </div>`).join('') +
     '</div>';
   } catch (_) {
@@ -525,8 +525,12 @@ async function loadPostList() {
   }
 }
 
-async function deletePost(id) {
+async function deletePost(id, btn) {
   if (!confirm('Delete this post?')) return;
+  if (btn) {
+    btn.disabled = true;
+    btn.textContent = 'Deleting...';
+  }
   const r = await apiFetch(api('/board/admin/delete/post'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -538,6 +542,10 @@ async function deletePost(id) {
     fb('postListFb', '✓ Post deleted');
   } else {
     fb('postListFb', '✗ Delete failed');
+    if (btn) {
+      btn.disabled = false;
+      btn.textContent = 'Delete';
+    }
   }
 }
 


### PR DESCRIPTION
**💡 What:** 
Added a loading state to the post deletion action in `admin.html` and a contextual `aria-label` to the delete button.

**🎯 Why:**
In the vanilla JS admin panel, clicking "Delete" previously provided no immediate visual feedback while waiting for the backend request to complete. This could lead to users wondering if the click registered or attempting duplicate submissions. Additionally, the delete buttons lacked context for screen reader users.

**📸 Before/After:**
*(See Playwright verification screenshot for the new "Deleting..." disabled state)*

**♿ Accessibility:**
Added `aria-label="Delete post by [author]"` to give screen reader users context about which post the button will delete, rather than just announcing "Delete".

---
*PR created automatically by Jules for task [13779113736716193541](https://jules.google.com/task/13779113736716193541) started by @LokiMetaSmith*