### PR TITLE
🎨 Palette: Add inline validation feedback to Community Hub board

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -25,3 +25,7 @@
 ## 2024-11-21 - Passing element context in vanilla JS lists
 **Learning:** When rendering dynamic lists with string interpolation in vanilla JS (like in `admin.html`), it can be tricky to grab the exact button element later to apply loading states, especially if the button lacks a unique ID.
 **Action:** When adding inline onclick handlers in template literals (e.g., `onclick="deletePost(${id}, this)"`), pass `this` to give the function a direct reference to the clicked element, making it easy to toggle disabled states and text content immediately.
+
+## 2024-11-21 - [Vanilla JS Silent Form Validations]
+**Learning:** In vanilla JavaScript frontends, simply returning early (`if (!value) return;`) on empty form submissions creates a silent failure where the user clicks the button but nothing happens, which is confusing and poor UX/a11y.
+**Action:** When catching empty required inputs in vanilla JS functions, always use the existing `aria-live` hint/error containers to display a clear error message, and immediately call `.focus()` on the empty input to guide the user to the required action.

--- a/main/web_assets/board.html
+++ b/main/web_assets/board.html
@@ -364,10 +364,10 @@ body {
     </div>
 
     <div class="field field-msg">
-      <label for="msgIn">Message</label>
+      <label for="msgIn">Message <span style="color: var(--c-need-bar);" aria-hidden="true">*</span></label>
       <textarea id="msgIn" maxlength="300"
                 placeholder="What's on the board?"
-                spellcheck="false"></textarea>
+                spellcheck="false" aria-required="true"></textarea>
       <div class="char-hint" id="msgHint" aria-live="polite"></div>
     </div>
 
@@ -587,7 +587,14 @@ function render(data) {
 async function doPost() {
   const n = document.getElementById('nameIn').value.trim() || 'neighbor';
   const t = document.getElementById('msgIn').value.trim();
-  if (!t) return;
+  const hint = document.getElementById('msgHint');
+
+  if (!t) {
+    hint.textContent = 'Message is required to post.';
+    hint.className = 'char-hint warn';
+    document.getElementById('msgIn').focus();
+    return;
+  }
 
   const btn = document.getElementById('postBtn');
   if (btn) {


### PR DESCRIPTION
**💡 What:** Replaced silent failures on empty message submission with actionable inline validation in the Community Hub board (`board.html`). Added visual required indicators, `aria-required="true"`, dynamic error messages using the existing `aria-live` hint text, and focus management on failure.

**🎯 Why:** Silent form failures are terrible UX. If a user tries to submit without the required information and nothing happens, they might think the application is broken or the network failed. Providing immediate, contextual feedback and moving focus to the invalid field guides them to correct the error effortlessly.

**📸 Before/After:**
*Before:* User leaves "Message" blank -> Clicks "POST" -> Nothing happens.
*After:* User leaves "Message" blank -> Clicks "POST" -> "Message is required to post." appears in red -> Textarea receives focus. (See verification video)

**♿ Accessibility:** Added `aria-required="true"` to the textarea so screen readers know it's mandatory. Error messages utilize the existing `aria-live="polite"` container, ensuring screen readers announce the validation failure automatically. Focus management ensures keyboard-only users don't have to tab back to the input manually.

---
*PR created automatically by Jules for task [12211984857455231497](https://jules.google.com/task/12211984857455231497) started by @LokiMetaSmith*