### PR TITLE
🎨 Palette: Add loading state to Format SD Card button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -36,3 +36,6 @@
 ## 2024-07-10 - Improve inline form validation feedback
 **Learning:** Returning silently when required inputs are empty creates a confusing user experience, as the user clicks a button and nothing appears to happen. Even though standard HTML forms have native validation (which we don't always use or rely on via JS), custom JavaScript logic should also provide explicit feedback.
 **Action:** Always provide actionable inline feedback by updating an existing `aria-live` container with an error message and immediately calling `.focus()` on the invalid input, so screen readers announce the issue and keyboard users can immediately fix it.
+## 2026-07-11 - Provide loading states for destructive async actions
+**Learning:** Destructive or potentially slow operations (like formatting an SD card) without immediate visual feedback can lead to duplicate clicks, user confusion, and perceived slowness.
+**Action:** Always provide immediate visual feedback for async operations by temporarily disabling the trigger button and updating its text (e.g., to a loading state), especially for destructive actions.

--- a/main/web_assets/admin.html
+++ b/main/web_assets/admin.html
@@ -312,7 +312,7 @@ textarea.restore-area:focus { border-color: var(--accent-dark); }
     <div class="section-head">Storage Management</div>
     <div class="section-body">
       <div class="row">
-        <button class="btn danger" onclick="confirmFormatSD()">Format SD Card</button>
+        <button class="btn danger" onclick="confirmFormatSD(this)">Format SD Card</button>
       </div>
       <div class="feedback" id="storageFb" aria-live="polite"></div>
     </div>
@@ -567,8 +567,13 @@ async function deletePost(id, btn) {
 }
 
 // ── Storage Management ────────────────────────────────────────────────────────
-function confirmFormatSD() {
+function confirmFormatSD(btn) {
   if (!confirm('Are you sure you want to format the SD card? All data will be lost.')) return;
+
+  if (btn) {
+    btn.disabled = true;
+    btn.textContent = 'Formatting...';
+  }
 
   apiFetch(api('/board/admin/format-sd'), { method: 'POST' })
     .then(r => {
@@ -578,7 +583,13 @@ function confirmFormatSD() {
         fb('storageFb', '✗ Failed to format SD Card');
       }
     })
-    .catch(() => fb('storageFb', '✗ Request failed'));
+    .catch(() => fb('storageFb', '✗ Request failed'))
+    .finally(() => {
+      if (btn) {
+        btn.disabled = false;
+        btn.textContent = 'Format SD Card';
+      }
+    });
 }
 
 // ── Lamp Color ────────────────────────────────────────────────────────────────

--- a/tests/e2e/test_ux.py
+++ b/tests/e2e/test_ux.py
@@ -38,6 +38,14 @@ def test_ux():
     assert "aria-label=\"Next Page\"" in viewer_content, "Missing Next Page aria-label in viewer.html"
     assert "title = \"Previous Page (Left Arrow)\"" in viewer_content, "Missing keyboard hint tooltip in viewer.html"
 
+    with open(os.path.join(base_dir, 'main/web_assets/admin.html'), 'r') as f:
+        admin_content = f.read()
+
+    assert "onclick=\"confirmFormatSD(this)\"" in admin_content, "Missing 'this' parameter in confirmFormatSD call"
+    assert "btn.disabled = true" in admin_content, "Missing disabled state in confirmFormatSD"
+    assert "Formatting..." in admin_content, "Missing loading text in confirmFormatSD"
+    assert ".finally" in admin_content, "Missing finally block in confirmFormatSD"
+
     print("All assertions passed. Modifications are successfully present.")
 
 if __name__ == "__main__":


### PR DESCRIPTION
💡 **What**: Added a loading state to the "Format SD Card" button in the Admin Panel.
🎯 **Why**: Formatting an SD card is a destructive and potentially slow operation. The UI previously provided no immediate visual feedback that the operation had started, which could lead users to click the button multiple times or think the application was unresponsive.
📸 **Before/After**: 
- **Before**: Button text remained "Format SD Card" and the button remained clickable while waiting for the network response.
- **After**: Button becomes disabled and text changes to "Formatting..." immediately upon confirmation, restoring when the operation completes.
♿ **Accessibility**: Prevents confusing duplicate actions and improves perceived responsiveness for all users, particularly those relying on visual feedback for system state changes.

---
*PR created automatically by Jules for task [12392582461838768562](https://jules.google.com/task/12392582461838768562) started by @LokiMetaSmith*