### PR TITLE
🎨 Palette: Item-specific loading states for destructive actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -42,3 +42,6 @@
 ## 2026-07-12 - Provide loading states for standard HTML form submissions
 **Learning:** Even when not using async JS (like `fetch`), standard HTML forms submitting to slow backends (like an ESP32 saving credentials and restarting Wi-Fi) leave the user hanging without feedback, which can lead to multiple clicks and confusion.
 **Action:** When using standard HTML `<form>` submissions, add a simple `onsubmit` handler to disable the submit button and update its text (e.g., to "Connecting...") to provide immediate visual feedback during the page navigation delay.
+## 2024-11-25 - Item-specific async state tracking in Vue lists
+**Learning:** When dealing with async operations (like file deletion) inside a `v-for` list, using a simple boolean `isDeleting` state affects all items in the list, disabling all buttons simultaneously or requiring complex index tracking. Without feedback, the user isn't sure which item is being deleted.
+**Action:** When tracking async states for items in dynamic lists, assign the item's unique identifier (e.g., `this.isDeleting = file.name`) to the state variable instead of a boolean. Then, in the template, bind states specific to that item (`:disabled="isDeleting === file.name"` and change text to "Deleting..."), providing clear, isolated feedback for destructive actions without complex state management.

--- a/main/web_assets/index.html
+++ b/main/web_assets/index.html
@@ -82,7 +82,7 @@
                             </div>
                             <button @click="transferToEReader(file.name)" :disabled="!isEReaderConnected || transfer.active" :title="transfer.active ? 'A transfer is currently in progress' : (!isEReaderConnected ? 'Connect an E-Reader to transfer books' : 'Transfer to E-Reader')" :aria-label="'Transfer ' + file.title + ' to E-Reader'">Transfer to E-Reader</button>
                             <a class="sleep-btn" style="text-decoration: none;" v-if="file.name.toLowerCase().endsWith('.epub')" :href="'/viewer.html?file=' + encodeURIComponent(file.name) + '&source=sd'" :aria-label="'Read ' + file.title">Read</a>
-                            <button v-if="isAdmin" @click="deleteFile(file.name, 'sd')" class="btn danger" style="background-color: #c94b4b; color: white;" :aria-label="'Delete ' + file.title">Delete</button>
+                            <button v-if="isAdmin" @click="deleteFile(file.name, 'sd')" class="btn danger" style="background-color: #c94b4b; color: white;" :aria-label="'Delete ' + file.title" :disabled="isDeleting === file.name || transfer.active" :title="isDeleting === file.name ? 'Deleting file...' : (transfer.active ? 'Action unavailable during transfer' : 'Delete file')">{{ isDeleting === file.name ? 'Deleting...' : 'Delete' }}</button>
                             <button v-if="transfer.active && transfer.filename === file.name" @click="cancelTransfer" class="cancel-btn" :aria-label="'Cancel transfer for ' + file.title">Cancel</button>
                         </div>
                     </li>
@@ -107,7 +107,7 @@
                                     <div class="progress-bar" :style="{ width: transfer.progress + '%' }"></div>
                                 </div>
                                 <button @click="transferToLibrary(file.name)" :disabled="transfer.active" :title="transfer.active ? 'A transfer is currently in progress' : 'Transfer to Library'" :aria-label="'Transfer ' + file.title + ' to Library'">Transfer to Library</button>
-                                <button v-if="isAdmin" @click="deleteFile(file.name, 'usb')" class="btn danger" style="background-color: #c94b4b; color: white;" :aria-label="'Delete ' + file.title">Delete</button>
+                                <button v-if="isAdmin" @click="deleteFile(file.name, 'usb')" class="btn danger" style="background-color: #c94b4b; color: white;" :aria-label="'Delete ' + file.title" :disabled="isDeleting === file.name || transfer.active" :title="isDeleting === file.name ? 'Deleting file...' : (transfer.active ? 'Action unavailable during transfer' : 'Delete file')">{{ isDeleting === file.name ? 'Deleting...' : 'Delete' }}</button>
                                 <button v-if="transfer.active && transfer.filename === file.name" @click="cancelTransfer" class="cancel-btn" :aria-label="'Cancel transfer for ' + file.title">Cancel</button>
                             </div>
                         </li>

--- a/main/web_assets/script.js
+++ b/main/web_assets/script.js
@@ -24,7 +24,8 @@ createApp({
             uploadTitle: '',
             uploadAuthor: '',
             isUploading: false,
-            uploadError: ''
+            uploadError: '',
+            isDeleting: null
         }
     },
     computed: {
@@ -117,6 +118,7 @@ createApp({
         async deleteFile(filename, source) {
             if (!confirm(`Are you sure you want to delete ${filename}?`)) return;
 
+            this.isDeleting = filename;
             let url = '/delete-file';
             const savedKey = localStorage.getItem('adminKey');
             if (savedKey) {
@@ -139,6 +141,8 @@ createApp({
             } catch (error) {
                 console.error('Delete error:', error);
                 alert('An error occurred while deleting the file.');
+            } finally {
+                this.isDeleting = null;
             }
         },
         transferToEReader(filename) {


### PR DESCRIPTION
**💡 What:** Added visual loading states and disabled feedback to the "Delete" buttons in the Local Library and E-Reader file lists.
**🎯 Why:** To provide immediate visual feedback when an asynchronous deletion is processing, preventing duplicate clicks and reducing user confusion.
**📸 Before/After:** Before: Clicking delete did nothing visually until the file disappeared. After: The specific button being clicked changes to "Deleting..." and disables itself.
**♿ Accessibility:** Enhanced screen reader experience by clarifying the button state and using dynamic `title` attributes alongside existing `aria-labels`. Addressed in `.jules/palette.md`.

---
*PR created automatically by Jules for task [6885494888192926510](https://jules.google.com/task/6885494888192926510) started by @LokiMetaSmith*