### PR TITLE
🎨 Palette: Add password visibility toggle to Wi-Fi setup page

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -55,3 +55,6 @@
 ## 2024-11-25 - [Form Required Indicators]
 **Learning:** Found an accessibility and UX issue in `index.html` where form inputs like `uploadFile`, `uploadTitle`, and `uploadAuthor` used the native `required` attribute for validation but had no visible indicator (like an asterisk) on their labels. Users could not distinguish mandatory fields from optional ones visually until they failed validation. Providing explicit visual cues makes forms much more predictable and prevents frustration.
 **Action:** Always pair programmatic `required` attributes with a visible indicator on the corresponding `<label>`, such as `<span aria-hidden="true" style="color: #ff8a80;">*</span>`, so users can see which fields are mandatory before attempting to submit.
+## 2024-07-20 - [Hardware Setup Password Visibility]
+**Learning:** In IoT device setup portals (like `setup.html`), mistyping a Wi-Fi password is a common point of failure that often requires hard-resetting the device. Providing a "Show/Hide" password toggle significantly reduces this friction and improves the overall UX of the onboarding process.
+**Action:** When creating or modifying hardware network setup forms, always include a toggle to unmask the password input to prevent user error.

--- a/main/web_assets/setup.html
+++ b/main/web_assets/setup.html
@@ -9,8 +9,8 @@
         .container { max-width: 400px; padding: 30px; background-color: #fff; border-radius: 8px; box-shadow: 0 4px 6px rgba(0,0,0,0.1); text-align: center; }
         h1 { color: #1877f2; margin-bottom: 20px; }
         p { color: #555; margin-bottom: 30px; }
-        input[type="text"], input[type="password"] { width: 90%; padding: 12px; margin-bottom: 20px; border: 1px solid #ddd; border-radius: 6px; font-size: 1em; }
-        button { background-color: #1877f2; color: white; border: none; padding: 12px 20px; border-radius: 6px; cursor: pointer; font-size: 1.1em; width: 98%; transition: background-color 0.2s; }
+        input[type="text"], input[type="password"] { width: 90%; padding: 12px; margin-bottom: 20px; border: 1px solid #ddd; border-radius: 6px; font-size: 1em; box-sizing: border-box; }
+        button { background-color: #1877f2; color: white; border: none; padding: 12px 20px; border-radius: 6px; cursor: pointer; font-size: 1.1em; width: 98%; transition: background-color 0.2s; box-sizing: border-box; }
         button:hover { background-color: #166fe5; }
         .status-message { margin-top: 20px; font-weight: bold; }
         .success { color: #28a745; }
@@ -23,12 +23,15 @@
         <p>Connect your E-Book Librarian to your local Wi-Fi network.</p>
         <form action="/save-credentials" method="POST" onsubmit="const btn = this.querySelector('button[type=submit]'); btn.disabled = true; btn.textContent = 'Connecting...'; return true;">
             <div style="margin-bottom: 15px;">
-                <label for="ssid" style="display: block; text-align: left; margin-bottom: 5px; font-weight: bold; color: #555;">Wi-Fi Network Name (SSID) <span aria-hidden="true" class="error">*</span></label>
+                <label for="ssid" style="display: block; text-align: left; margin-bottom: 5px; font-weight: bold; color: #555; margin-left: 5%;">Wi-Fi Network Name (SSID) <span aria-hidden="true" class="error">*</span></label>
                 <input type="text" id="ssid" name="ssid" required style="margin-bottom: 0;">
             </div>
             <div style="margin-bottom: 20px;">
-                <label for="password" style="display: block; text-align: left; margin-bottom: 5px; font-weight: bold; color: #555;">Password</label>
-                <input type="password" id="password" name="password" style="margin-bottom: 0;">
+                <label for="password" style="display: block; text-align: left; margin-bottom: 5px; font-weight: bold; color: #555; margin-left: 5%;">Password</label>
+                <div style="display: flex; gap: 8px; width: 90%; margin: 0 auto;">
+                    <input type="password" id="password" name="password" style="margin-bottom: 0; width: 100%;">
+                    <button type="button" onclick="const p = document.getElementById('password'); const isPass = p.type === 'password'; p.type = isPass ? 'text' : 'password'; this.textContent = isPass ? 'Hide' : 'Show'; this.setAttribute('aria-pressed', isPass);" aria-label="Show password" aria-pressed="false" style="width: 80px; padding: 0; background-color: #6c757d; font-size: 0.9em; flex-shrink: 0;">Show</button>
+                </div>
             </div>
             <button type="submit">Connect</button>
         </form>

--- a/test_setup_ux.py
+++ b/test_setup_ux.py
@@ -1,0 +1,43 @@
+from playwright.sync_api import sync_playwright
+import os
+
+def test_setup_page():
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+
+        # Open the setup page
+        base_dir = os.path.dirname(os.path.abspath(__file__))
+        file_url = f"file://{base_dir}/main/web_assets/setup.html"
+        page.goto(file_url)
+
+        # Verify initial state
+        password_input = page.locator("#password")
+        assert password_input.get_attribute("type") == "password"
+
+        show_btn = page.locator("button[aria-label='Show password']")
+        assert show_btn.text_content() == "Show"
+        assert show_btn.get_attribute("aria-pressed") == "false"
+
+        # Click show button
+        show_btn.click()
+
+        # Verify unmasked state
+        assert password_input.get_attribute("type") == "text"
+        assert show_btn.text_content() == "Hide"
+        assert show_btn.get_attribute("aria-pressed") == "true"
+
+        # Click hide button
+        show_btn.click()
+
+        # Verify masked state
+        assert password_input.get_attribute("type") == "password"
+        assert show_btn.text_content() == "Show"
+        assert show_btn.get_attribute("aria-pressed") == "false"
+
+        print("Setup page UX verified successfully.")
+
+        browser.close()
+
+if __name__ == "__main__":
+    test_setup_page()


### PR DESCRIPTION
💡 **What:** Added a "Show/Hide" password toggle button to the Wi-Fi configuration form on the `setup.html` page. Also adjusted the CSS layout to properly align the labels and fields.
🎯 **Why:** In IoT hardware setups, typing the Wi-Fi password correctly is critical, as a typo often requires a frustrating hard-reset of the device. Allowing the user to unmask their password significantly reduces this friction.
📸 **Before/After:** Look at the generated screenshots and videos. The password field now sits next to a native "Show/Hide" toggle button.
♿ **Accessibility:** The toggle button includes an `aria-label="Show password"` and dynamically updates `aria-pressed="true/false"` when toggled to ensure screen readers announce its state.


---
*PR created automatically by Jules for task [17620224689546482370](https://jules.google.com/task/17620224689546482370) started by @LokiMetaSmith*