### PR TITLE
🎨 Palette: [UX improvement] Dynamic ARIA labels for password toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -58,3 +58,6 @@
 ## 2024-07-20 - [Hardware Setup Password Visibility]
 **Learning:** In IoT device setup portals (like `setup.html`), mistyping a Wi-Fi password is a common point of failure that often requires hard-resetting the device. Providing a "Show/Hide" password toggle significantly reduces this friction and improves the overall UX of the onboarding process.
 **Action:** When creating or modifying hardware network setup forms, always include a toggle to unmask the password input to prevent user error.
+## 2024-07-21 - [Dynamic ARIA labels for Toggle Buttons]
+**Learning:** Found an accessibility issue where an inline password "Show/Hide" toggle button updated its visual text and `aria-pressed` state, but its `aria-label` and `title` attributes remained static (e.g., permanently reading "Show password"). This causes screen readers to announce incorrect information and limits usability for keyboard users relying on tooltips.
+**Action:** When implementing toggle buttons that change functionality (like showing/hiding a password), ensure you dynamically update both the `aria-label` and `title` attributes alongside the visual text to provide accurate context for all users.

--- a/main/web_assets/setup.html
+++ b/main/web_assets/setup.html
@@ -30,7 +30,7 @@
                 <label for="password" style="display: block; text-align: left; margin-bottom: 5px; font-weight: bold; color: #555; margin-left: 5%;">Password</label>
                 <div style="display: flex; gap: 8px; width: 90%; margin: 0 auto;">
                     <input type="password" id="password" name="password" style="margin-bottom: 0; width: 100%;">
-                    <button type="button" onclick="const p = document.getElementById('password'); const isPass = p.type === 'password'; p.type = isPass ? 'text' : 'password'; this.textContent = isPass ? 'Hide' : 'Show'; this.setAttribute('aria-pressed', isPass);" aria-label="Show password" aria-pressed="false" style="width: 80px; padding: 0; background-color: #6c757d; font-size: 0.9em; flex-shrink: 0;">Show</button>
+                    <button type="button" onclick="const p = document.getElementById('password'); const isPass = p.type === 'password'; p.type = isPass ? 'text' : 'password'; const label = isPass ? 'Hide password' : 'Show password'; this.textContent = isPass ? 'Hide' : 'Show'; this.setAttribute('aria-pressed', isPass); this.setAttribute('aria-label', label); this.title = label;" aria-label="Show password" title="Show password" aria-pressed="false" style="width: 80px; padding: 0; background-color: #6c757d; font-size: 0.9em; flex-shrink: 0;">Show</button>
                 </div>
             </div>
             <button type="submit">Connect</button>


### PR DESCRIPTION
### 💡 What
Updated the password visibility toggle button in `main/web_assets/setup.html` to dynamically change its `aria-label` and `title` attributes. 

### 🎯 Why
Previously, when the user clicked the button to reveal the password, the visual text changed from "Show" to "Hide", but the `aria-label` incorrectly remained static as "Show password" and it lacked a tooltip `title`. This created a confusing experience for screen reader users and those relying on keyboard focus tooltips.

### 📸 Before/After
- **Before:** Button text toggled, but `<button aria-label="Show password" ...>` remained static. No tooltip provided.
- **After:** Both `aria-label` and `title` dynamically toggle between "Show password" and "Hide password" depending on the visible state of the input.

### ♿ Accessibility
- Provides accurate context to screen readers on state changes.
- Provides helpful `title` tooltips for hover/focus interactions.

---
*PR created automatically by Jules for task [15656758276762681767](https://jules.google.com/task/15656758276762681767) started by @LokiMetaSmith*