### PR TITLE
🎨 Palette: Add Show/Hide toggle to Admin Access gate

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -61,3 +61,6 @@
 ## 2024-07-21 - [Dynamic ARIA labels for Toggle Buttons]
 **Learning:** Found an accessibility issue where an inline password "Show/Hide" toggle button updated its visual text and `aria-pressed` state, but its `aria-label` and `title` attributes remained static (e.g., permanently reading "Show password"). This causes screen readers to announce incorrect information and limits usability for keyboard users relying on tooltips.
 **Action:** When implementing toggle buttons that change functionality (like showing/hiding a password), ensure you dynamically update both the `aria-label` and `title` attributes alongside the visual text to provide accurate context for all users.
+## 2024-11-25 - [Hardware Admin Password Visibility]
+**Learning:** In authentication forms on hardware portals (like the admin gate in `admin.html`), users typing complex or long access keys often mistype them. Providing a "Show/Hide" password toggle alongside the input prevents this frustration.
+**Action:** Always wrap password inputs in a flex container with a "Show/Hide" button that toggles the input type and dynamically updates its `aria-label` and `title` for screen readers and keyboard users.

--- a/main/web_assets/admin.html
+++ b/main/web_assets/admin.html
@@ -208,7 +208,10 @@ textarea.restore-area:focus { border-color: var(--accent-dark); }
 <div id="gate">
   <h2>Admin Access</h2>
   <label for="keyIn">Admin Access Key</label>
-  <input type="password" id="keyIn" autocomplete="off">
+  <div style="display: flex; gap: 8px; margin-bottom: 10px;">
+    <input type="password" id="keyIn" autocomplete="off" style="margin-bottom: 0;">
+    <button type="button" onclick="const p = document.getElementById('keyIn'); const isPass = p.type === 'password'; p.type = isPass ? 'text' : 'password'; const label = isPass ? 'Hide key' : 'Show key'; this.textContent = isPass ? 'Hide' : 'Show'; this.setAttribute('aria-pressed', isPass); this.setAttribute('aria-label', label); this.title = label;" aria-label="Show key" title="Show key" aria-pressed="false" style="width: 70px; padding: 0; font-size: 0.9em; flex-shrink: 0; background-color: #6c757d; border-color: #5a6268;">Show</button>
+  </div>
   <button id="loginBtn" onclick="tryLogin()">Unlock 🔑</button>
   <div class="error" id="gateErr" aria-live="assertive"></div>
 </div>


### PR DESCRIPTION
**💡 What:** Added a "Show/Hide" visibility toggle to the Admin Access Key password input on the `admin.html` page.
**🎯 Why:** In authentication forms on hardware portals (like the admin gate), users typing complex or long access keys often mistype them, leading to access denial and frustration. Providing a way to unmask the password input prevents this issue.
**📸 Before/After:** See attached Playwright verification screenshots (`admin_initial.png` and `admin_toggled.png`).
**♿ Accessibility:** The "Show/Hide" button is wrapped in a flex layout for visual consistency. The toggle button dynamically updates `aria-pressed`, `aria-label`, and `title` attributes based on state, ensuring screen readers and keyboard users receive the correct context when interacting with the button.

---
*PR created automatically by Jules for task [7537984952351823203](https://jules.google.com/task/7537984952351823203) started by @LokiMetaSmith*