### PR TITLE
🎨 Palette: Add password visibility toggle to Admin Key form

### DIFF
--- a/main/web_assets/admin.html
+++ b/main/web_assets/admin.html
@@ -225,13 +225,19 @@ textarea.restore-area:focus { border-color: var(--accent-dark); }
       <div class="row">
         <div class="fld">
           <label for="newKey">New Key (min 4 characters)</label>
-          <input type="password" id="newKey" maxlength="64" autocomplete="new-password"
-                 placeholder="Enter new key" style="width:200px">
+          <div style="display: flex; gap: 8px;">
+            <input type="password" id="newKey" maxlength="64" autocomplete="new-password"
+                   placeholder="Enter new key" style="width:200px; margin-bottom: 0;">
+            <button type="button" class="btn" onclick="const p = document.getElementById('newKey'); const isPass = p.type === 'password'; p.type = isPass ? 'text' : 'password'; const label = isPass ? 'Hide new key' : 'Show new key'; this.textContent = isPass ? 'Hide' : 'Show'; this.setAttribute('aria-pressed', isPass); this.setAttribute('aria-label', label); this.title = label;" aria-label="Show new key" title="Show new key" aria-pressed="false" style="padding: 0 10px;">Show</button>
+          </div>
         </div>
         <div class="fld">
           <label for="newKeyConfirm">Confirm</label>
-          <input type="password" id="newKeyConfirm" maxlength="64"
-                 placeholder="Confirm new key" style="width:200px">
+          <div style="display: flex; gap: 8px;">
+            <input type="password" id="newKeyConfirm" maxlength="64"
+                   placeholder="Confirm new key" style="width:200px; margin-bottom: 0;">
+            <button type="button" class="btn" onclick="const p = document.getElementById('newKeyConfirm'); const isPass = p.type === 'password'; p.type = isPass ? 'text' : 'password'; const label = isPass ? 'Hide confirmed key' : 'Show confirmed key'; this.textContent = isPass ? 'Hide' : 'Show'; this.setAttribute('aria-pressed', isPass); this.setAttribute('aria-label', label); this.title = label;" aria-label="Show confirmed key" title="Show confirmed key" aria-pressed="false" style="padding: 0 10px;">Show</button>
+          </div>
         </div>
         <button class="btn" onclick="doSetKey(this)">Change Key</button>
       </div>

--- a/test_plan.sh
+++ b/test_plan.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "Testing..."

--- a/tests/e2e/test_ux.py
+++ b/tests/e2e/test_ux.py
@@ -49,6 +49,11 @@ def test_ux():
     assert "onclick=\"doSetLampColor(this)\"" in admin_content, "Missing 'this' parameter in doSetLampColor call"
     assert "Setting..." in admin_content, "Missing loading text in doSetLampColor"
 
+    # Admin Key Show/Hide feature verification
+    assert "Show new key" in admin_content, "Missing 'Show new key' aria-label/title"
+    assert "Hide new key" in admin_content, "Missing 'Hide new key' logic"
+    assert "Show confirmed key" in admin_content, "Missing 'Show confirmed key' aria-label/title"
+
     print("All assertions passed. Modifications are successfully present.")
 
 if __name__ == "__main__":


### PR DESCRIPTION
### 💡 What
Added a "Show/Hide" toggle to the "New Key" and "Confirm" password inputs on the `admin.html` admin key change form.

### 🎯 Why
In IoT device interfaces like the ESP32 Admin panel, typing a new access key is a critical configuration step. Mistyping it can lock administrators out of their device entirely, potentially requiring a hard reset of the hardware to recover. Allowing users to temporarily unmask the password fields to verify what they typed significantly reduces this risk.

### 📸 Before/After
**Before:**
Users had to guess if they typed the complex key correctly.
**After:**
Users can click "Show" to reveal their typed key. The layout dynamically uses a flex-box to align the button seamlessly next to the input.

### ♿ Accessibility
The inline JavaScript for the toggle dynamically updates the `aria-pressed`, `aria-label`, and `title` attributes along with the button's visual text. This ensures that screen readers accurately announce the current state of the button (e.g., whether it will currently "Show" or "Hide" the password) and keyboard users receive contextual tooltips.

---
*PR created automatically by Jules for task [13111802173981384540](https://jules.google.com/task/13111802173981384540) started by @LokiMetaSmith*