### PR TITLE
🎨 Palette: Add accessible text labels to system status indicator

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -64,3 +64,6 @@
 ## 2024-11-25 - [Hardware Admin Password Visibility]
 **Learning:** In authentication forms on hardware portals (like the admin gate in `admin.html`), users typing complex or long access keys often mistype them. Providing a "Show/Hide" password toggle alongside the input prevents this frustration.
 **Action:** Always wrap password inputs in a flex container with a "Show/Hide" button that toggles the input type and dynamically updates its `aria-label` and `title` for screen readers and keyboard users.
+## 2024-11-25 - Non-Text Status Indicators
+**Learning:** Using only colored visual indicators (like the `.status-indicator` dot) to represent system state fails colorblind users and screen readers, violating WCAG guidelines which state color should not be the only visual means of conveying information.
+**Action:** When creating visual status indicators, always bind a human-readable text description to `title` (for hover) and `aria-label` (for screen readers), and use `role="status"` to announce dynamic changes to the system state.

--- a/main/web_assets/index.html
+++ b/main/web_assets/index.html
@@ -30,7 +30,7 @@
             </div>
         </div>
             <h1>E-Book Librarian</h1>
-            <div class="status-indicator" :class="statusClass"></div>
+            <div class="status-indicator" :class="statusClass" :title="statusText" :aria-label="statusText" role="status"></div>
         </header>
         <main class="app-main">
             <div class="library-section">

--- a/main/web_assets/script.js
+++ b/main/web_assets/script.js
@@ -33,6 +33,11 @@ createApp({
             if (this.transfer.active) return 'status-transferring';
             if (this.isEReaderConnected) return 'status-connected';
             return 'status-idle';
+        },
+        statusText() {
+            if (this.transfer.active) return 'Transferring';
+            if (this.isEReaderConnected) return 'E-Reader Connected';
+            return 'System Idle';
         }
     },
     methods: {


### PR DESCRIPTION
💡 **What**: Added descriptive `title` and `aria-label` attributes, along with `role="status"`, to the colored system status indicator dot on the main library page.

🎯 **Why**: The status indicator (the pulsing dot next to "E-Book Librarian") previously relied *entirely* on color (green, blue, orange) to convey the system's state (Idle, Connected, Transferring). This violates WCAG accessibility guidelines as it is inaccessible to colorblind users who might not distinguish the colors, and invisible to screen readers since it had no text alternative.

📸 **Before/After**:
- **Before:** `<div class="status-indicator status-idle"></div>` (Relying solely on color for state)
- **After:** `<div class="status-indicator status-idle" title="System Idle" aria-label="System Idle" role="status"></div>` (Provides a hover tooltip for mouse users and semantic labels for screen readers).

♿ **Accessibility**: 
- **Screen Readers**: Users will now hear the state announced (e.g., "System Idle", "E-Reader Connected") instead of silence when navigating past the header, thanks to `aria-label` and `role="status"`.
- **Colorblind Users**: Mouse/keyboard users who cannot distinguish the colors can now hover or focus the element to see a native browser tooltip explaining the current state.

---
*PR created automatically by Jules for task [8709420185572203234](https://jules.google.com/task/8709420185572203234) started by @LokiMetaSmith*