### PR TITLE
🎨 Palette: [UX improvement] Add progressbar a11y

### DIFF
--- a/main/web_assets/index.html
+++ b/main/web_assets/index.html
@@ -77,7 +77,7 @@
                             <span v-if="file.notes" class="file-notes">{{ file.notes }}</span>
                         </div>
                         <div class="transfer-controls">
-                            <div class="progress-container" v-if="transfer.active && transfer.filename === file.name">
+                            <div class="progress-container" v-if="transfer.active && transfer.filename === file.name" role="progressbar" aria-valuemin="0" aria-valuemax="100" :aria-valuenow="Math.round(transfer.progress)" :aria-label="'Transfer progress for ' + file.title" :title="Math.round(transfer.progress) + '%'">
                                 <div class="progress-bar" :style="{ width: transfer.progress + '%' }"></div>
                             </div>
                             <button @click="transferToEReader(file.name)" :disabled="!isEReaderConnected || transfer.active" :title="transfer.active ? 'A transfer is currently in progress' : (!isEReaderConnected ? 'Connect an E-Reader to transfer books' : 'Transfer to E-Reader')" :aria-label="'Transfer ' + file.title + ' to E-Reader'">Transfer to E-Reader</button>
@@ -103,7 +103,7 @@
                                 <span v-if="file.notes" class="file-notes">{{ file.notes }}</span>
                             </div>
                             <div class="transfer-controls">
-                                <div class="progress-container" v-if="transfer.active && transfer.filename === file.name">
+                                <div class="progress-container" v-if="transfer.active && transfer.filename === file.name" role="progressbar" aria-valuemin="0" aria-valuemax="100" :aria-valuenow="Math.round(transfer.progress)" :aria-label="'Transfer progress for ' + file.title" :title="Math.round(transfer.progress) + '%'">
                                     <div class="progress-bar" :style="{ width: transfer.progress + '%' }"></div>
                                 </div>
                                 <button @click="transferToLibrary(file.name)" :disabled="transfer.active" :title="transfer.active ? 'A transfer is currently in progress' : 'Transfer to Library'" :aria-label="'Transfer ' + file.title + ' to Library'">Transfer to Library</button>


### PR DESCRIPTION
**💡 What**
Added ARIA attributes (`role`, `aria-valuemin`, `aria-valuemax`, `:aria-valuenow`, `:aria-label`) and a `title` tooltip to the `.progress-container` elements used during USB file transfers in `index.html`.

**🎯 Why**
Previously, the visual progress bar used `<div>` elements whose width was adjusted via inline styles, meaning its state and existence were completely hidden from assistive technologies like screen readers. Sighted users could see the progress bar moving, but could not read the exact percentage. This change exposes the loading status and exact percentage to all users.

**📸 Before/After**
*   **Before:** `<div class="progress-container" v-if="transfer.active && transfer.filename === file.name">`
*   **After:** `<div class="progress-container" v-if="transfer.active && transfer.filename === file.name" role="progressbar" aria-valuemin="0" aria-valuemax="100" :aria-valuenow="Math.round(transfer.progress)" :aria-label="'Transfer progress for ' + file.title" :title="Math.round(transfer.progress) + '%'">`

**♿ Accessibility**
*   Adds `role="progressbar"` to expose the element's semantic meaning to the accessibility tree.
*   Adds `aria-valuemin`, `aria-valuemax`, and dynamic `:aria-valuenow` to announce the exact numeric progress to screen reader users.
*   Adds `:aria-label` to provide context (which file is being transferred).
*   Adds `:title` to surface the percentage on mouse hover for sighted users.

---
*PR created automatically by Jules for task [1588389336733496546](https://jules.google.com/task/1588389336733496546) started by @LokiMetaSmith*