### PR TITLE
🎨 Palette: Add loading state to Refresh List button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,4 +1,4 @@
-## 2026-06-19 - [Form Accessibility]
+## 2024-06-19 - [Form Accessibility]
 **Learning:** Found several input fields relying solely on placeholders or lacking 'for' attributes on labels, which hurts screen reader users and reduces click targets.
 **Action:** Always pair inputs with explicit <label for="..."> elements to improve both accessibility and usability.
 ## 2024-07-04 - [Board Category Accessibility]
@@ -67,3 +67,6 @@
 ## 2024-11-25 - Non-Text Status Indicators
 **Learning:** Using only colored visual indicators (like the `.status-indicator` dot) to represent system state fails colorblind users and screen readers, violating WCAG guidelines which state color should not be the only visual means of conveying information.
 **Action:** When creating visual status indicators, always bind a human-readable text description to `title` (for hover) and `aria-label` (for screen readers), and use `role="status"` to announce dynamic changes to the system state.
+## 2025-01-20 - [Vanilla JS Missing Loading State for Action Buttons]
+**Learning:** In `admin.html`, the "Refresh List" button lacked a loading state during a fetch operation. In vanilla JS, a button click that triggers a backend process must explicitly disable itself and change its label to prevent rapid double-clicks and confusion about whether the request registered.
+**Action:** For action buttons like "Refresh List" relying on an async backend call, modify the inline `onclick` handler to pass `this` and update the button's `disabled` and `textContent` properties at the start, and ensure a `finally` block is used to restore the button when the call completes.

--- a/main/web_assets/admin.html
+++ b/main/web_assets/admin.html
@@ -281,7 +281,7 @@ textarea.restore-area:focus { border-color: var(--accent-dark); }
     <div class="section-head">Manage Posts</div>
     <div class="section-body">
       <div class="row">
-        <button class="btn" onclick="loadPostList()">Refresh List</button>
+        <button class="btn" onclick="loadPostList(this)">Refresh List</button>
         <button class="btn danger" onclick="confirmClear(this)">Clear All Posts</button>
       </div>
       <div id="postListFb" class="feedback" aria-live="polite"></div>
@@ -566,7 +566,11 @@ function timeLeftShort(exp) {
   return Math.floor(left/86400) + 'd';
 }
 
-async function loadPostList() {
+async function loadPostList(btn) {
+  if (btn) {
+    btn.disabled = true;
+    btn.textContent = 'Refreshing...';
+  }
   const container = document.getElementById('postList');
   container.innerHTML = '<div class="post-empty">Loading…</div>';
   try {
@@ -588,6 +592,11 @@ async function loadPostList() {
     '</div>';
   } catch (_) {
     container.innerHTML = '<div class="post-empty">Failed to load posts.</div>';
+  } finally {
+    if (btn) {
+      btn.disabled = false;
+      btn.textContent = 'Refresh List';
+    }
   }
 }
 


### PR DESCRIPTION
🎨 Palette: Add loading state to Refresh List button

This PR improves the micro-UX of the `admin.html` page by adding a missing loading state to the "Refresh List" button during async post loading.

### 💡 What
Modified the `loadPostList()` function to accept a `btn` parameter. Passed `this` into the inline `onclick` handler. The button text changes to "Refreshing..." and it becomes disabled until the `fetch` request completes.

### 🎯 Why
Prevents confusing situations where a user clicks the button multiple times because of server or connection latency, providing immediate visual feedback of ongoing network requests.

### 📸 Before/After
When clicked, the button updates text to "Refreshing..." and appears slightly faded/dimmed according to the existing disabled CSS styling until data loading is complete.

### ♿ Accessibility
Disabling the button while working prevents potential focus and keyboard trigger spam on slow connections.

---
*PR created automatically by Jules for task [208319622614322921](https://jules.google.com/task/208319622614322921) started by @LokiMetaSmith*