### PR TITLE
🎨 Palette: Add Escape key shortcut to e-book viewer

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -22,3 +22,6 @@
 ## 2024-12-05 - [Item-Specific Loading States in Vue]
 **Learning:** When users click action buttons inside a dynamic Vue list (like adding or removing tracks in a queue), failing to provide item-specific loading states can result in double-clicks that spam the backend or cause confusion. Binding specific identifiers (like the filename or index) to a tracking variable provides immediate, targeted visual feedback (e.g., disabling only the clicked button).
 **Action:** Always implement and bind item-specific loading states (e.g., `this.addingToQueue = filename`) for asynchronous actions triggered within `v-for` lists.
+## 2024-07-28 - Keyboard Exit Shortcuts in Immersive Views
+**Learning:** When building full-screen or immersive interfaces (like the e-book viewer) that support keyboard navigation for primary actions (e.g., arrow keys for page turning), users intuitively expect a complementary keyboard shortcut (like `Escape`) to exit or go back. Without it, keyboard-only users must disrupt their reading flow to manually tab through the interface to find a back button.
+**Action:** Always pair primary keyboard navigation in immersive views with an intuitive "exit" or "back" shortcut (e.g., `Escape`), and explicitly document the shortcut in the UI (e.g., via tooltips or aria-labels).

--- a/main/web_assets/viewer.html
+++ b/main/web_assets/viewer.html
@@ -16,7 +16,7 @@
 </head>
 <body>
     <div class="toolbar">
-        <a href="javascript:history.back()" id="backBtn">Back</a>
+        <a href="javascript:history.back()" id="backBtn" title="Go back (Escape)" aria-label="Go back (Escape)">Back</a>
         <div>
             <button id="prevBtn" disabled title="Loading book..." aria-label="Previous Page">&#8592; Prev</button>
             <button id="nextBtn" disabled title="Loading book..." aria-label="Next Page">Next &#8594;</button>
@@ -72,6 +72,7 @@
             document.addEventListener("keyup", function(e) {
                 if (e.key === "ArrowLeft") rendition.prev();
                 if (e.key === "ArrowRight") rendition.next();
+                if (e.key === "Escape") document.getElementById('backBtn').click();
             });
         }
     </script>


### PR DESCRIPTION
### 💡 What:
Added an `Escape` key shortcut to the E-Book Viewer's "Back" button, allowing users to easily exit the immersive reading view. The button was also updated with a `title` and `aria-label` to document the shortcut.

### 🎯 Why:
Users reading e-books often navigate with the keyboard (Arrow keys). Without an `Escape` shortcut, keyboard users must disrupt their reading flow to manually tab out or use the mouse to click the "Back" button to return to the library.

### ♿ Accessibility:
The added `aria-label` ensures screen reader users have clear context about the button's action and the available keyboard shortcut.

### 📸 Before/After:
Before: `Back` button with no tooltip, requiring a mouse click or manual tabbing to exit.
After: `Back` button with `title="Go back (Escape)"` and functional `Escape` key listener.

---
*PR created automatically by Jules for task [12899207461242346571](https://jules.google.com/task/12899207461242346571) started by @LokiMetaSmith*