### PR TITLE
feat: add robust ESP-IDF setup scripts for Bash and PowerShell

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -1,0 +1,127 @@
+# We need to determine if this script is being sourced (dot-sourced) or executed.
+# In PowerShell, $MyInvocation.InvocationName is '.' when dot-sourced.
+$IsSourced = ($MyInvocation.InvocationName -eq '.')
+
+if (-not $IsSourced) {
+    Write-Host "Warning: This script should be dot-sourced, not executed directly." -ForegroundColor Yellow
+    Write-Host "Please run: . .\setup.ps1" -ForegroundColor Yellow
+}
+
+Write-Host "Setting up ESP32 Dev Environment for E-Book Librarian..."
+
+# Automatically set the required environment variable for this project
+$env:SDKCONFIG = "sdkconfig.esp32-s3-ebook-librarian"
+Write-Host "Set SDKCONFIG=$env:SDKCONFIG"
+
+# Check if idf.py is already available in the current PATH
+if (Get-Command idf.py -ErrorAction SilentlyContinue) {
+    Write-Host "ESP-IDF is already in PATH. Environment is ready." -ForegroundColor Green
+    if ($IsSourced) { return } else { exit }
+}
+
+# Define the expected ESP-IDF version
+$IDF_VERSION = "v5.4.1"
+$DEFAULT_IDF_DIR = Join-Path $HOME "esp\esp-idf"
+$IDF_EXPORT_SCRIPT = ""
+
+# Function to search for export.ps1 in a given directory
+function Find-ExportScript {
+    param([string]$Dir)
+    $ScriptPath = Join-Path $Dir "export.ps1"
+    if (Test-Path $ScriptPath) {
+        return $ScriptPath
+    }
+    return $null
+}
+
+# 1. Check if IDF_PATH is already set and has export.ps1
+if ($env:IDF_PATH) {
+    $IDF_EXPORT_SCRIPT = Find-ExportScript $env:IDF_PATH
+    if ($IDF_EXPORT_SCRIPT) {
+        Write-Host "Found ESP-IDF based on IDF_PATH: $IDF_EXPORT_SCRIPT"
+    }
+}
+
+# 2. Check the default ESP-IDF installation directory
+if (-not $IDF_EXPORT_SCRIPT) {
+    $IDF_EXPORT_SCRIPT = Find-ExportScript $DEFAULT_IDF_DIR
+    if ($IDF_EXPORT_SCRIPT) {
+        Write-Host "Found ESP-IDF in default location: $IDF_EXPORT_SCRIPT"
+    }
+}
+
+# 3. Check PlatformIO's framework-espidf directory
+if (-not $IDF_EXPORT_SCRIPT) {
+    $PioDir = Join-Path $HOME ".platformio\packages\framework-espidf"
+    $IDF_EXPORT_SCRIPT = Find-ExportScript $PioDir
+    if ($IDF_EXPORT_SCRIPT) {
+        Write-Host "Found ESP-IDF in PlatformIO location: $IDF_EXPORT_SCRIPT"
+    }
+}
+
+# If we found an export script, try sourcing it
+if ($IDF_EXPORT_SCRIPT) {
+    Write-Host "Sourcing ESP-IDF environment from: $IDF_EXPORT_SCRIPT"
+    . $IDF_EXPORT_SCRIPT
+
+    # Check if sourcing it actually worked
+    if (-not (Get-Command idf.py -ErrorAction SilentlyContinue)) {
+        Write-Host "WARNING: Sourced $IDF_EXPORT_SCRIPT but idf.py is still not in PATH." -ForegroundColor Yellow
+        Write-Host "The existing ESP-IDF installation might be broken. Falling back to fresh installation..." -ForegroundColor Yellow
+        $IDF_EXPORT_SCRIPT = ""
+    }
+}
+
+# If we didn't find an export script, or if the one we found was broken, do a fresh install
+if (-not $IDF_EXPORT_SCRIPT) {
+    Write-Host "Downloading and installing a fresh ESP-IDF $IDF_VERSION..."
+
+    $EspDir = Join-Path $HOME "esp"
+    if (-not (Test-Path $EspDir)) {
+        New-Item -ItemType Directory -Path $EspDir | Out-Null
+    }
+
+    $GitDir = Join-Path $DEFAULT_IDF_DIR ".git"
+    if (Test-Path $GitDir) {
+        Write-Host "Directory $DEFAULT_IDF_DIR exists. Attempting to run install script on existing repository..."
+    } else {
+        # Clone ESP-IDF
+        git clone -b $IDF_VERSION --recursive https://github.com/espressif/esp-idf.git $DEFAULT_IDF_DIR
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "Error: Failed to clone ESP-IDF repository." -ForegroundColor Red
+            if ($IsSourced) { return } else { exit 1 }
+        }
+    }
+
+    Write-Host "Installing ESP-IDF tools..."
+    $InstallScript = Join-Path $DEFAULT_IDF_DIR "install.ps1"
+    & $InstallScript
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Error: Failed to install ESP-IDF tools." -ForegroundColor Red
+        if ($IsSourced) { return } else { exit 1 }
+    }
+
+    $IDF_EXPORT_SCRIPT = Join-Path $DEFAULT_IDF_DIR "export.ps1"
+
+    # Source the newly installed script
+    Write-Host "Sourcing new ESP-IDF environment from: $IDF_EXPORT_SCRIPT"
+    . $IDF_EXPORT_SCRIPT
+}
+
+if (-not $IsSourced) {
+    Write-Host "=========================================================================" -ForegroundColor Yellow
+    Write-Host "WARNING: You executed this script directly instead of dot-sourcing it." -ForegroundColor Yellow
+    Write-Host "The environment variables (including idf.py) will NOT be available in your current terminal." -ForegroundColor Yellow
+    Write-Host "Please run this command to finish setup in your current terminal:" -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "    . .\setup.ps1" -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "=========================================================================" -ForegroundColor Yellow
+} else {
+    if (Get-Command idf.py -ErrorAction SilentlyContinue) {
+        Write-Host "Environment setup complete! You can now use 'idf.py build' and other commands." -ForegroundColor Green
+    } else {
+        Write-Host "Error: Setup failed. idf.py is not available." -ForegroundColor Red
+    }
+}

--- a/setup.sh
+++ b/setup.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 
 # We need to determine if this script is being sourced or executed.
-# This script must be sourced to properly set environment variables for the user.
-# In bash, BASH_SOURCE[0] is the script name. If it equals $0, it's executed directly.
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     echo "Warning: This script should be sourced, not executed directly."
     echo "Please run: source ${BASH_SOURCE[0]} or . ${BASH_SOURCE[0]}"
@@ -13,22 +11,18 @@ fi
 
 echo "Setting up ESP32 Dev Environment for E-Book Librarian..."
 
-# Automatically set the required environment variable for this project
 export SDKCONFIG="sdkconfig.esp32-s3-ebook-librarian"
 echo "Set SDKCONFIG=$SDKCONFIG"
 
-# Check if idf.py is already available in the current PATH
 if command -v idf.py &> /dev/null; then
     echo "ESP-IDF is already in PATH. Environment is ready."
     if [ "$IS_SOURCED" = "1" ]; then return 0; else exit 0; fi
 fi
 
-# Define the expected ESP-IDF version
 IDF_VERSION="v5.4.1"
 DEFAULT_IDF_DIR="$HOME/esp/esp-idf"
 IDF_EXPORT_SCRIPT=""
 
-# Function to search for export.sh in a given directory
 find_export_script() {
     if [ -f "$1/export.sh" ]; then
         echo "$1/export.sh"
@@ -51,23 +45,43 @@ elif find_export_script "$HOME/.platformio/packages/framework-espidf" > /dev/nul
     echo "Found ESP-IDF in PlatformIO location: $IDF_EXPORT_SCRIPT"
 fi
 
-# If we still haven't found it, we need to download and install it
-if [ -z "$IDF_EXPORT_SCRIPT" ]; then
-    echo "ESP-IDF not found. Downloading ESP-IDF $IDF_VERSION..."
+# If we found an export script, try sourcing it
+if [ -n "$IDF_EXPORT_SCRIPT" ]; then
+    echo "Sourcing ESP-IDF environment from: $IDF_EXPORT_SCRIPT"
+    if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
+        . "$IDF_EXPORT_SCRIPT"
+    else
+        . "$IDF_EXPORT_SCRIPT"
+    fi
 
-    # Create the esp directory if it doesn't exist
+    # Check if sourcing it actually worked (idf.py is in PATH)
+    if ! command -v idf.py &> /dev/null; then
+        echo "WARNING: Sourced $IDF_EXPORT_SCRIPT but idf.py is still not in PATH."
+        echo "The existing ESP-IDF installation might be broken or missing the Python environment."
+        echo "Falling back to fresh installation..."
+        IDF_EXPORT_SCRIPT=""
+    fi
+fi
+
+# If we didn't find an export script, or if the one we found was broken, do a fresh install
+if [ -z "$IDF_EXPORT_SCRIPT" ]; then
+    echo "Downloading and installing a fresh ESP-IDF $IDF_VERSION..."
+
     mkdir -p "$HOME/esp"
 
-    # Clone ESP-IDF
-    git clone -b $IDF_VERSION --recursive https://github.com/espressif/esp-idf.git "$DEFAULT_IDF_DIR"
-
-    if [ $? -ne 0 ]; then
-        echo "Error: Failed to clone ESP-IDF repository."
-        if [ "$IS_SOURCED" = "1" ]; then return 1; else exit 1; fi
+    # If the default dir already exists but is broken, we should remove it first or install over it.
+    # We will try to run install.sh on it first if it's already a git repo.
+    if [ -d "$DEFAULT_IDF_DIR/.git" ]; then
+        echo "Directory $DEFAULT_IDF_DIR exists. Attempting to run install script on existing repository..."
+    else
+        git clone -b $IDF_VERSION --recursive https://github.com/espressif/esp-idf.git "$DEFAULT_IDF_DIR"
+        if [ $? -ne 0 ]; then
+            echo "Error: Failed to clone ESP-IDF repository."
+            if [ "$IS_SOURCED" = "1" ]; then return 1; else exit 1; fi
+        fi
     fi
 
     echo "Installing ESP-IDF tools..."
-    # Support for Windows (Git Bash) and Linux
     if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
         "$DEFAULT_IDF_DIR/install.bat"
     else
@@ -80,32 +94,25 @@ if [ -z "$IDF_EXPORT_SCRIPT" ]; then
     fi
 
     IDF_EXPORT_SCRIPT="$DEFAULT_IDF_DIR/export.sh"
+
+    # Source the newly installed script
+    echo "Sourcing new ESP-IDF environment from: $IDF_EXPORT_SCRIPT"
+    . "$IDF_EXPORT_SCRIPT"
 fi
 
-# Finally, source the export script
-if [ -f "$IDF_EXPORT_SCRIPT" ]; then
-    echo "Sourcing ESP-IDF environment from: $IDF_EXPORT_SCRIPT"
-    if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
-        # In Windows Git Bash, we might need to source export.bat or just run the sh version.
-        # Usually export.sh works in Git Bash, but let's be explicit
-        . "$IDF_EXPORT_SCRIPT"
-    else
-        . "$IDF_EXPORT_SCRIPT"
-    fi
-
-    if [ "$IS_SOURCED" = "0" ]; then
-        echo "========================================================================="
-        echo "WARNING: You executed this script directly instead of sourcing it."
-        echo "The environment variables (including idf.py) will NOT be available in your current terminal."
-        echo "Please run this command to finish setup in your current terminal:"
-        echo ""
-        echo "    source ./setup.sh"
-        echo ""
-        echo "========================================================================="
-    else
-        echo "Environment setup complete! You can now use 'idf.py build' and other commands."
-    fi
+if [ "$IS_SOURCED" = "0" ]; then
+    echo "========================================================================="
+    echo "WARNING: You executed this script directly instead of sourcing it."
+    echo "The environment variables (including idf.py) will NOT be available in your current terminal."
+    echo "Please run this command to finish setup in your current terminal:"
+    echo ""
+    echo "    source ./setup.sh"
+    echo ""
+    echo "========================================================================="
 else
-    echo "Error: Could not find or access $IDF_EXPORT_SCRIPT."
-    if [ "$IS_SOURCED" = "1" ]; then return 1; else exit 1; fi
+    if command -v idf.py &> /dev/null; then
+        echo "Environment setup complete! You can now use 'idf.py build' and other commands."
+    else
+        echo "Error: Setup failed. idf.py is not available."
+    fi
 fi


### PR DESCRIPTION
Added `setup.sh` and `setup.ps1` to the root directory to automate the initialization of the ESP-IDF toolchain. The scripts automatically search for existing installations across common directories (`$IDF_PATH`, `~/esp/esp-idf`, and `~/.platformio`), natively support Linux, Git for Windows, and PowerShell, set the required project specific `SDKCONFIG` variable, and fall back to cloning and installing ESP-IDF version `v5.4.1` if an existing installation is not found on the system or is broken.