### PR TITLE
fix: update usb_host components for ESP-IDF v5.4.1 compatibility

### DIFF
--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,8 +1,8 @@
 ## IDF Component Manager Manifest File
 dependencies:
   idf: ">=4.4"
-  espressif/usb_host_hid: "^2.0.0"
-  espressif/usb_host_msc: "^2.0.0"
+  espressif/usb_host_hid: "*"
+  espressif/usb_host_msc: "*"
   espressif/led_strip: "^3.0.0"
   jgromes/radiolib: "*"
   espressif/cjson: "^1.7.17"


### PR DESCRIPTION
Updated the `espressif/usb_host_msc` and `espressif/usb_host_hid` dependencies in `main/idf_component.yml` to use wildcard `*` resolving. This forces the IDF component manager to fetch the latest published compatible versions from the registry, resolving compilation errors caused by missing HAL functions (`usb_dwc_hal_fifo_config_is_valid`) when compiling against the newer ESP-IDF v5.4.1 framework.