### PR TITLE
🎨 Palette: [UX improvement] Add native required attribute to board message input

### DIFF
--- a/main/web_assets/board.html
+++ b/main/web_assets/board.html
@@ -367,7 +367,7 @@ body {
       <label for="msgIn">Message <span style="color: var(--c-need-bar);" aria-hidden="true">*</span></label>
       <textarea id="msgIn" maxlength="300"
                 placeholder="What's on the board?"
-                spellcheck="false" aria-required="true"></textarea>
+                spellcheck="false" aria-required="true" required></textarea>
       <div class="char-hint" id="msgHint" aria-live="polite"></div>
     </div>
 


### PR DESCRIPTION
**💡 What:** 
Added the native `required` attribute to the `msgIn` textarea in `board.html`.

**🎯 Why:**
The "Message" field is visually indicated as required (with an asterisk) and has `aria-required="true"`, but it was missing the native HTML5 `required` attribute. Adding this enables native browser form validation, preventing users from attempting to submit an empty form and relying solely on custom JavaScript alerts. This creates a more consistent and accessible user experience.

**📸 Before/After:**
- **Before:** Submitting an empty form bypassed browser validation and triggered a custom JS message.
- **After:** Submitting an empty form triggers native browser validation, immediately focusing the empty `textarea` and showing a tooltip.

**♿ Accessibility:** 
Improves accessibility by ensuring standard HTML5 validation behavior is triggered, which screen readers handle natively, keeping behavior consistent with other forms in the application.

---
*PR created automatically by Jules for task [9402924132196733591](https://jules.google.com/task/9402924132196733591) started by @LokiMetaSmith*