### PR TITLE
🎨 Palette: Add contextual placeholders to Board Identity inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -14,3 +14,7 @@
 ## 2026-12-10 - Implicit Form Submission
 **Learning:** In custom admin panel layouts (e.g., `admin.html`), using `<div>` wrappers instead of `<form>` elements prevents users from submitting forms using the Enter key natively and bypasses built-in HTML5 validation like `minlength`.
 **Action:** When creating form inputs, always wrap them in a `<form>` tag and include a `<button type="submit">`. Use `onsubmit="event.preventDefault(); ..."` to intercept the action while maintaining standard accessibility and browser behaviors.
+
+## 2026-12-11 - [Input Placeholder Examples in Forms]
+**Learning:** Adding `placeholder` attributes with clear examples (e.g., "e.g., Neighborhood Library") to form inputs significantly improves the UX of configuration pages by reducing cognitive load and demonstrating the expected data format.
+**Action:** When adding or updating configuration or management forms, always provide contextual `placeholder` text on empty input fields to guide the user.

--- a/main/web_assets/admin.html
+++ b/main/web_assets/admin.html
@@ -251,24 +251,24 @@ textarea.restore-area:focus { border-color: var(--accent-dark); }
       <div class="row">
         <div class="fld" style="flex:0 0 60px">
           <label for="idIcon">Icon</label>
-          <input type="text" id="idIcon" maxlength="4" style="width:60px;font-size:20px;text-align:center;padding:4px 6px;">
+          <input type="text" id="idIcon" maxlength="4" placeholder="📚" style="width:60px;font-size:20px;text-align:center;padding:4px 6px;">
         </div>
         <div class="fld" style="flex:1 1 200px">
           <label for="idName">Board Name</label>
-          <input type="text" id="idName" maxlength="48" style="width:100%">
+          <input type="text" id="idName" maxlength="48" placeholder="e.g., Neighborhood Library" style="width:100%">
         </div>
       </div>
       <div class="fld" style="flex:1">
         <label for="idTagline">Tagline</label>
-        <input type="text" id="idTagline" maxlength="80" style="width:100%">
+        <input type="text" id="idTagline" maxlength="80" placeholder="e.g., A place to share and discover books" style="width:100%">
       </div>
       <div class="fld" style="flex:1">
         <label for="idRules">Rules</label>
-        <input type="text" id="idRules" maxlength="80" style="width:100%">
+        <input type="text" id="idRules" maxlength="80" placeholder="e.g., Be kind and keep it clean" style="width:100%">
       </div>
       <div class="fld" style="flex:1">
         <label for="idFooter">Footer</label>
-        <input type="text" id="idFooter" maxlength="80" style="width:100%">
+        <input type="text" id="idFooter" maxlength="80" placeholder="e.g., Maintained by neighborhood volunteers" style="width:100%">
       </div>
       <div class="row">
         <button class="btn" onclick="doIdentity(this)">Save Identity</button>


### PR DESCRIPTION
💡 **What:** Added helpful `placeholder` attributes with examples (e.g., "e.g., Neighborhood Library") to the Board Identity inputs (Icon, Board Name, Tagline, Rules, Footer) in `admin.html`.
🎯 **Why:** The previous form had empty inputs without guidance. Placeholders provide inline context and reduce cognitive load for administrators configuring their board, making the UI more intuitive.
📸 **Before/After:** The admin identity fields now show grayed-out example text when empty. (Verified via local testing).
♿ **Accessibility:** Improves general usability by providing immediate context for form fields.

---
*PR created automatically by Jules for task [1562049077846043657](https://jules.google.com/task/1562049077846043657) started by @LokiMetaSmith*