### PR TITLE
🎨 Palette: Add placeholders to setup inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -18,3 +18,7 @@
 ## 2026-12-11 - [Input Placeholder Examples in Forms]
 **Learning:** Adding `placeholder` attributes with clear examples (e.g., "e.g., Neighborhood Library") to form inputs significantly improves the UX of configuration pages by reducing cognitive load and demonstrating the expected data format.
 **Action:** When adding or updating configuration or management forms, always provide contextual `placeholder` text on empty input fields to guide the user.
+
+## 2026-12-11 - [Input Placeholder Examples in Setup Form]
+**Learning:** Adding `placeholder` attributes with clear examples (e.g., "e.g., MyHomeNetwork" and "e.g., MySecretPassword") to configuration inputs in `setup.html` significantly improves the UX by reducing cognitive load and demonstrating the expected data format for the hardware portal.
+**Action:** When creating or maintaining configuration and setup forms, always ensure text and password inputs have descriptive `placeholder` attributes.

--- a/main/web_assets/setup.html
+++ b/main/web_assets/setup.html
@@ -24,12 +24,12 @@
         <form action="/save-credentials" method="POST" onsubmit="const btn = this.querySelector('button[type=submit]'); btn.disabled = true; btn.textContent = 'Connecting...'; return true;">
             <div style="margin-bottom: 15px;">
                 <label for="ssid" style="display: block; text-align: left; margin-bottom: 5px; font-weight: bold; color: #555; margin-left: 5%;">Wi-Fi Network Name (SSID) <span aria-hidden="true" style="color: #dc3545;">*</span></label>
-                <input type="text" id="ssid" name="ssid" required style="margin-bottom: 0;">
+                <input type="text" id="ssid" name="ssid" placeholder="e.g., MyHomeNetwork" required style="margin-bottom: 0;">
             </div>
             <div style="margin-bottom: 20px;">
                 <label for="password" style="display: block; text-align: left; margin-bottom: 5px; font-weight: bold; color: #555; margin-left: 5%;">Password</label>
                 <div style="display: flex; gap: 8px; width: 90%; margin: 0 auto;">
-                    <input type="password" id="password" name="password" style="margin-bottom: 0; width: 100%;">
+                    <input type="password" id="password" name="password" placeholder="e.g., MySecretPassword" style="margin-bottom: 0; width: 100%;">
                     <button type="button" onclick="const p = document.getElementById('password'); const isPass = p.type === 'password'; p.type = isPass ? 'text' : 'password'; const label = isPass ? 'Hide password' : 'Show password'; this.textContent = isPass ? 'Hide' : 'Show'; this.setAttribute('aria-pressed', isPass); this.setAttribute('aria-label', label); this.title = label;" aria-label="Show password" title="Show password" aria-pressed="false" style="width: 80px; padding: 0; background-color: #6c757d; font-size: 0.9em; flex-shrink: 0;">Show</button>
                 </div>
             </div>

--- a/verify.py
+++ b/verify.py
@@ -1,0 +1,25 @@
+from playwright.sync_api import sync_playwright
+import os
+
+def run_cuj(page):
+    page.goto("file:///app/main/web_assets/setup.html")
+    page.wait_for_timeout(500)
+
+    # Assert placeholders are visible
+    page.screenshot(path="/home/jules/verification/screenshots/verification.png")
+    page.wait_for_timeout(1000)
+
+if __name__ == "__main__":
+    os.makedirs("/home/jules/verification/videos", exist_ok=True)
+    os.makedirs("/home/jules/verification/screenshots", exist_ok=True)
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        context = browser.new_context(
+            record_video_dir="/home/jules/verification/videos"
+        )
+        page = context.new_page()
+        try:
+            run_cuj(page)
+        finally:
+            context.close()
+            browser.close()


### PR DESCRIPTION
💡 What: Added placeholder text attributes to the Wi-Fi Network Name (SSID) and Password input fields in the `setup.html` page.
🎯 Why: To provide contextual guidance and reduce cognitive load for users when configuring their device's Wi-Fi connection.
📸 Before/After: The inputs previously had no placeholders, meaning users lacked inline examples of expected input. Now they clearly guide the user with examples like "e.g., MyHomeNetwork".
♿ Accessibility: Improves usability and comprehension by following standard form best practices.

---
*PR created automatically by Jules for task [1482898741388697647](https://jules.google.com/task/1482898741388697647) started by @LokiMetaSmith*