### PR TITLE
🎨 Palette: [UX improvement] Visible character limits in Bulletin Board

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-12-11 - [Implicit Form Submission in Admin Portal]
 **Learning:** The "Board Identity" configuration section in the Admin portal used a generic `<div>` wrapper with a standard button calling a JavaScript function on click. This setup prevented users from pressing the "Enter" key to submit the form, which is a common expectation for multi-input forms. By replacing the `<div>` with a `<form>` tag, adding an `onsubmit` handler with `event.preventDefault()`, and changing the button to `type="submit"`, native implicit form submission is enabled while retaining the existing JavaScript logic and CSS styling.
 **Action:** When building or updating multi-input configuration sections that require submission, always use semantic `<form>` tags and `type="submit"` buttons, handling the event via `onsubmit` rather than `onclick` to ensure native keyboard accessibility.
+
+## 2026-12-11 - [Visible Character Limits in Text Inputs]
+**Learning:** Character count hints on input fields that only appear when the user is close to the limit (e.g., `n > 18` for a 24-character max) can leave the user guessing their remaining characters for most of the typing experience.
+**Action:** When creating forms with character limits on inputs, always display the character count explicitly (e.g., "0/24") right from the beginning and update it continuously as the user types, rather than hiding it conditionally.

--- a/main/web_assets/board.html
+++ b/main/web_assets/board.html
@@ -456,20 +456,29 @@ let activeSort    = 'new';
 
 // ── Restore name from localStorage ────────────
 const savedName = localStorage.getItem('cn_name');
-if (savedName) document.getElementById('nameIn').value = savedName;
+if (savedName) {
+  const nameInput = document.getElementById('nameIn');
+  nameInput.value = savedName;
+  const nameHint = document.getElementById('nameHint');
+  nameHint.textContent = savedName.length + '/24';
+  if (savedName.length > 20) nameHint.className = 'char-hint warn';
+} else {
+  document.getElementById('nameHint').textContent = '0/24';
+}
+document.getElementById('msgHint').textContent = '0/300';
 
 document.getElementById('nameIn').addEventListener('input', function () {
   localStorage.setItem('cn_name', this.value);
   const h = document.getElementById('nameHint');
   const n = this.value.length;
-  h.textContent = n > 18 ? n + '/24' : '';
+  h.textContent = n + '/24';
   h.className   = 'char-hint' + (n > 20 ? ' warn' : '');
 });
 
 document.getElementById('msgIn').addEventListener('input', function () {
   const h = document.getElementById('msgHint');
   const n = this.value.length;
-  h.textContent = n > 240 ? n + '/300' : '';
+  h.textContent = n + '/300';
   h.className   = 'char-hint' + (n > 270 ? ' warn' : '');
 });
 


### PR DESCRIPTION
What: Modified the JS character counter logic in `board.html` to always explicitly display the character count (e.g., '0/24' and '0/300') for the Name and Message inputs right from the start, and update continuously. Also ensures it is initialized correctly on page load when a name is restored from `localStorage`.
Why: Character counts previously remained hidden until the user was almost at the limit (e.g. >18 chars for a 24-character max limit). This left users guessing how much they could type. Always showing the limit gives immediate, visible guidance.
Before/After: See PR attachments.
Accessibility: The `nameHint` and `msgHint` containers already correctly use `aria-live="polite"`. Making the text content visible from the start ensures screen readers are consistently updated from the first keypress.

---
*PR created automatically by Jules for task [11237988665196952062](https://jules.google.com/task/11237988665196952062) started by @LokiMetaSmith*