### PR TITLE
🎨 Palette: [UX improvement] Add visual Sort label

### DIFF
--- a/main/web_assets/board.html
+++ b/main/web_assets/board.html
@@ -397,7 +397,8 @@ body {
     <button class="ftab" aria-pressed="false" onclick="setFilter('Request',  this)">🔍 Request</button>
   </div>
   <span class="sep"></span>
-  <div role="group" aria-label="Sort" style="display: flex; gap: 6px; flex-wrap: wrap; align-items: center;">
+  <span class="filter-label" id="sortLabel">Sort:</span>
+  <div role="group" aria-labelledby="sortLabel" style="display: flex; gap: 6px; flex-wrap: wrap; align-items: center;">
     <button class="ftab active" id="sNew" aria-pressed="true" onclick="setSort('new', this)">New</button>
     <button class="ftab"        id="sExp" aria-pressed="false" onclick="setSort('exp', this)">Expiring</button>
   </div>


### PR DESCRIPTION
🎨 Palette: Add explicit visual Sort label for custom button group

### What
Added a visible `Sort:` label element.

### Why
Previously the sorting button group ("New", "Expiring") had an `aria-label` but no visible text label. Sighted users had no clear context that these buttons were for sorting.

### Before/After
Added `<span class="filter-label" id="sortLabel">Sort:</span>` directly before the sort group and linked it via `aria-labelledby`.

### Accessibility
Using `aria-labelledby` linking to a visible element provides a better experience for both screen readers and sighted users, replacing the invisible `aria-label`.

---
*PR created automatically by Jules for task [13722297742484616612](https://jules.google.com/task/13722297742484616612) started by @LokiMetaSmith*