### PR TITLE
🎨 Palette: [Provide contextual placeholders for upload form]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,6 @@
 ## 2024-07-28 - Keyboard Exit Shortcuts in Immersive Views
 **Learning:** When building full-screen or immersive interfaces (like the e-book viewer) that support keyboard navigation for primary actions (e.g., arrow keys for page turning), users intuitively expect a complementary keyboard shortcut (like `Escape`) to exit or go back. Without it, keyboard-only users must disrupt their reading flow to manually tab through the interface to find a back button.
 **Action:** Always pair primary keyboard navigation in immersive views with an intuitive "exit" or "back" shortcut (e.g., `Escape`), and explicitly document the shortcut in the UI (e.g., via tooltips or aria-labels).
+## 2026-06-25 - [Contextual Placeholders]
+**Learning:** Found that primary forms like the "Upload Book" form in `index.html` were using placeholders that simply duplicated the label text (e.g., `placeholder="Title"` for the Title field). This fails to provide any extra value and does not help the user understand the expected input format. Using contextual examples (e.g., `placeholder="e.g., The Great Gatsby"`) reduces cognitive load and clarifies expectations.
+**Action:** When designing or updating forms, ensure that `placeholder` attributes provide clear, concrete examples of the expected input rather than just repeating the field label.

--- a/main/web_assets/index.html
+++ b/main/web_assets/index.html
@@ -50,11 +50,11 @@
                         </div>
                         <div>
                             <label for="uploadTitle" style="display: block; font-size: 0.9em; margin-bottom: 5px;">Title <span aria-hidden="true" style="color: #ff8a80;">*</span></label>
-                            <input type="text" id="uploadTitle" v-model="uploadTitle" placeholder="Title" required>
+                            <input type="text" id="uploadTitle" v-model="uploadTitle" placeholder="e.g., The Great Gatsby" required>
                         </div>
                         <div>
                             <label for="uploadAuthor" style="display: block; font-size: 0.9em; margin-bottom: 5px;">Author <span aria-hidden="true" style="color: #ff8a80;">*</span></label>
-                            <input type="text" id="uploadAuthor" v-model="uploadAuthor" placeholder="Author" required>
+                            <input type="text" id="uploadAuthor" v-model="uploadAuthor" placeholder="e.g., F. Scott Fitzgerald" required>
                         </div>
                         <button type="submit" :disabled="isUploading" :title="isUploading ? 'Upload in progress...' : 'Upload book'">
                             {{ isUploading ? 'Uploading...' : 'Upload' }}


### PR DESCRIPTION
### 💡 What
Updated the placeholder attributes for the Title and Author input fields in the local library "Upload Book" form to use contextual examples (`e.g., The Great Gatsby` and `e.g., F. Scott Fitzgerald`) instead of duplicating the field labels.

### 🎯 Why
Duplicating label text in placeholders offers no additional value and wastes an opportunity to clarify the expected input. By providing concrete examples, we reduce cognitive load and help users immediately understand what type of information they should enter, improving the overall usability of the form.

### 📸 Before/After
See attached screenshot for verification.

### ♿ Accessibility
This change improves clarity without relying on the placeholder as a label replacement, which aligns with best practices for accessible form design.

---
*PR created automatically by Jules for task [10242772873942318942](https://jules.google.com/task/10242772873942318942) started by @LokiMetaSmith*