### PR TITLE
🎨 Palette: Add aria-label to download links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -29,3 +29,7 @@
 ## 2026-12-11 - [Visible Character Limits in Text Inputs]
 **Learning:** Character count hints on input fields that only appear when the user is close to the limit (e.g., `n > 18` for a 24-character max) can leave the user guessing their remaining characters for most of the typing experience.
 **Action:** When creating forms with character limits on inputs, always display the character count explicitly (e.g., "0/24") right from the beginning and update it continuously as the user types, rather than hiding it conditionally.
+
+## 2026-12-11 - [ARIA Labels for Download Links]
+**Learning:** When using standard text links (like book titles) as download triggers, screen readers may announce just the title without clarifying the action. Adding an explicit `aria-label` (e.g., "Download The Great Gatsby") provides necessary context for visually impaired users.
+**Action:** Always append an explicit `aria-label` describing the action to text links that initiate downloads, especially in dynamic lists.

--- a/main/web_assets/ereader.html
+++ b/main/web_assets/ereader.html
@@ -163,6 +163,7 @@
                 titleLink.textContent = book.title;
                 // Link directly to the download endpoint
                 titleLink.href = `/download?file=${encodeURIComponent(book.name)}&source=sd`;
+                titleLink.setAttribute('aria-label', `Download ${book.title}`);
                 titleLink.style.display = 'block';
                 titleLink.style.marginBottom = '5px';
                 titleLink.style.textDecoration = 'none';


### PR DESCRIPTION
**What:** Added `aria-label` attribute to dynamically generated download links in `ereader.html` using the book's title.
**Why:** Screen readers will now announce "Download [Book Title]" instead of just reading the book title without context regarding the link's action, improving accessibility for visually impaired users.
**Accessibility:** Adds essential context to standalone text links that trigger a download rather than navigating to a new page, particularly beneficial in list views.

---
*PR created automatically by Jules for task [14422721908096525223](https://jules.google.com/task/14422721908096525223) started by @LokiMetaSmith*