### PR TITLE
🎨 Palette: Contextual Placeholders for Admin Keys

### DIFF
--- a/main/web_assets/admin.html
+++ b/main/web_assets/admin.html
@@ -209,7 +209,7 @@ textarea.restore-area:focus { border-color: var(--accent-dark); }
   <h2>Admin Access</h2>
   <label for="keyIn">Admin Access Key <span aria-hidden="true" style="color: #ff8a80;">*</span></label>
   <div style="display: flex; gap: 8px; margin-bottom: 10px;">
-    <input type="password" id="keyIn" autocomplete="off" style="margin-bottom: 0;" required>
+    <input type="password" id="keyIn" placeholder="e.g., MySecretAdminKey" autocomplete="off" style="margin-bottom: 0;" required>
     <button type="button" onclick="const p = document.getElementById('keyIn'); const isPass = p.type === 'password'; p.type = isPass ? 'text' : 'password'; const label = isPass ? 'Hide key' : 'Show key'; this.textContent = isPass ? 'Hide' : 'Show'; this.setAttribute('aria-pressed', isPass); this.setAttribute('aria-label', label); this.title = label;" aria-label="Show key" title="Show key" aria-pressed="false" style="width: 70px; padding: 0; font-size: 0.9em; flex-shrink: 0; background-color: #6c757d; border-color: #5a6268;">Show</button>
   </div>
   <button type="submit" id="loginBtn">Unlock 🔑</button>
@@ -227,7 +227,7 @@ textarea.restore-area:focus { border-color: var(--accent-dark); }
           <label for="newKey">New Key (min 4 characters) <span aria-hidden="true" style="color: #ff8a80;">*</span></label>
           <div style="display: flex; gap: 8px;">
             <input type="password" id="newKey" maxlength="64" minlength="4" autocomplete="new-password"
-                   placeholder="Enter new key" style="width:200px; margin-bottom: 0;" required>
+                   placeholder="e.g., MySecretAdminKey" style="width:200px; margin-bottom: 0;" required>
             <button type="button" class="btn" onclick="const p = document.getElementById('newKey'); const isPass = p.type === 'password'; p.type = isPass ? 'text' : 'password'; const label = isPass ? 'Hide new key' : 'Show new key'; this.textContent = isPass ? 'Hide' : 'Show'; this.setAttribute('aria-pressed', isPass); this.setAttribute('aria-label', label); this.title = label;" aria-label="Show new key" title="Show new key" aria-pressed="false" style="padding: 0 10px;">Show</button>
           </div>
         </div>
@@ -235,7 +235,7 @@ textarea.restore-area:focus { border-color: var(--accent-dark); }
           <label for="newKeyConfirm">Confirm <span aria-hidden="true" style="color: #ff8a80;">*</span></label>
           <div style="display: flex; gap: 8px;">
             <input type="password" id="newKeyConfirm" maxlength="64" minlength="4"
-                   placeholder="Confirm new key" style="width:200px; margin-bottom: 0;" required>
+                   placeholder="e.g., MySecretAdminKey" style="width:200px; margin-bottom: 0;" required>
             <button type="button" class="btn" onclick="const p = document.getElementById('newKeyConfirm'); const isPass = p.type === 'password'; p.type = isPass ? 'text' : 'password'; const label = isPass ? 'Hide confirmed key' : 'Show confirmed key'; this.textContent = isPass ? 'Hide' : 'Show'; this.setAttribute('aria-pressed', isPass); this.setAttribute('aria-label', label); this.title = label;" aria-label="Show confirmed key" title="Show confirmed key" aria-pressed="false" style="padding: 0 10px;">Show</button>
           </div>
         </div>


### PR DESCRIPTION
**💡 What:** Added contextual placeholder attributes (e.g., `placeholder="e.g., MySecretAdminKey"`) to the password input fields (`keyIn`, `newKey`, `newKeyConfirm`) in `admin.html`.
**🎯 Why:** The previous implementation either lacked placeholders entirely or used generic labels (like 'Enter new key'), providing minimal guidance to the user. Contextual examples clarify the expected input format and reduce cognitive load.
**📸 Before/After:** N/A (minor text/placeholder addition)
**♿ Accessibility:** Improves overall usability and provides clearer inline guidance for sighted users without negatively impacting screen readers (which still read the explicit `<label>` elements).

---
*PR created automatically by Jules for task [17158679302943909646](https://jules.google.com/task/17158679302943909646) started by @LokiMetaSmith*