### PR TITLE
🎨 Palette: Add tooltip to hamburger menu button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -33,3 +33,7 @@
 ## 2026-12-11 - [ARIA Labels for Download Links]
 **Learning:** When using standard text links (like book titles) as download triggers, screen readers may announce just the title without clarifying the action. Adding an explicit `aria-label` (e.g., "Download The Great Gatsby") provides necessary context for visually impaired users.
 **Action:** Always append an explicit `aria-label` describing the action to text links that initiate downloads, especially in dynamic lists.
+
+## 2026-12-11 - [ARIA Titles for Icon-Only Buttons]
+**Learning:** Icon-only buttons (like the hamburger menu) that rely on `aria-label` for screen reader accessibility often lack clear explanations for sighted users on hover, especially keyboard users. This reduces discoverability and can cause confusion about the button's function.
+**Action:** Always complement `aria-label` on icon-only buttons with a matching `title` attribute to provide a helpful tooltip for sighted mouse and keyboard users.

--- a/main/web_assets/about.html
+++ b/main/web_assets/about.html
@@ -9,7 +9,7 @@
 <body>
     <header class="app-header">
         <div class="nav-menu">
-            <button class="menu-btn" onclick="toggleMenu()" aria-label="Toggle Menu" aria-expanded="false" aria-controls="menuContent">☰</button>
+            <button class="menu-btn" onclick="toggleMenu()" aria-label="Toggle Menu" title="Toggle Menu" aria-expanded="false" aria-controls="menuContent">☰</button>
             <div class="menu-content" id="menuContent">
                 <a href="/">Home (USB Transfer View)</a>
                 <a href="/ereader.html">Mobile Download View</a>

--- a/main/web_assets/audio.html
+++ b/main/web_assets/audio.html
@@ -24,7 +24,7 @@
     <div id="audio-app">
         <header class="app-header">
             <div class="nav-menu">
-                <button class="menu-btn" onclick="toggleMenu()" aria-label="Toggle Menu" aria-expanded="false" aria-controls="menuContent">☰</button>
+                <button class="menu-btn" onclick="toggleMenu()" aria-label="Toggle Menu" title="Toggle Menu" aria-expanded="false" aria-controls="menuContent">☰</button>
                 <div class="menu-content" id="menuContent">
                     <a href="/">Home (USB Transfer View)</a>
                     <a href="/ereader.html">Mobile Download View</a>

--- a/main/web_assets/board.html
+++ b/main/web_assets/board.html
@@ -314,7 +314,7 @@ body {
 
 <header class="site-header">
   <div class="nav-menu" style="position: static; margin-right: 10px;">
-      <button class="menu-btn" onclick="toggleMenu()" aria-label="Toggle Menu" aria-expanded="false" aria-controls="menuContent" style="background: transparent; border: 1px solid var(--accent); color: var(--accent); padding: 4px 8px; font-size: 16px;">☰</button>
+      <button class="menu-btn" onclick="toggleMenu()" aria-label="Toggle Menu" title="Toggle Menu" aria-expanded="false" aria-controls="menuContent" style="background: transparent; border: 1px solid var(--accent); color: var(--accent); padding: 4px 8px; font-size: 16px;">☰</button>
       <div class="menu-content" id="menuContent" style="top: 60px;">
           <a href="/">Home (USB Transfer View)</a>
           <a href="/ereader.html">Mobile Download View</a>

--- a/main/web_assets/ereader.html
+++ b/main/web_assets/ereader.html
@@ -56,7 +56,7 @@
 
     <header class="app-header" style="max-width: 600px; border: none; box-shadow: none; background: transparent; padding: 0;">
         <div class="nav-menu">
-            <button class="menu-btn" onclick="toggleMenu()" aria-label="Toggle Menu" aria-expanded="false" aria-controls="menuContent">☰</button>
+            <button class="menu-btn" onclick="toggleMenu()" aria-label="Toggle Menu" title="Toggle Menu" aria-expanded="false" aria-controls="menuContent">☰</button>
             <div class="menu-content" id="menuContent">
                 <a href="/">Home (USB Transfer View)</a>
                 <a href="/ereader.html">Mobile Download View</a>

--- a/main/web_assets/index.html
+++ b/main/web_assets/index.html
@@ -10,7 +10,7 @@
     <div id="app">
         <header class="app-header">
         <div class="nav-menu">
-            <button class="menu-btn" onclick="toggleMenu()" aria-label="Toggle Menu" aria-expanded="false" aria-controls="menuContent">☰</button>
+            <button class="menu-btn" onclick="toggleMenu()" aria-label="Toggle Menu" title="Toggle Menu" aria-expanded="false" aria-controls="menuContent">☰</button>
             <div class="menu-content" id="menuContent">
                 <a href="/">Home (USB Transfer View)</a>
                 <a href="/ereader.html">Mobile Download View</a>


### PR DESCRIPTION
**💡 What:** Added a `title="Toggle Menu"` attribute to the hamburger menu button across all 5 main frontend views.
**🎯 Why:** The hamburger menu was an icon-only button ("☰") that had an `aria-label` for screen readers but lacked a native browser tooltip. This meant sighted users, particularly those navigating with a keyboard or encountering the interface for the first time, had no explicit explanation of what the icon did until clicked.
**📸 Before/After:** 
- Before: Hovering over the "☰" button showed nothing.
- After: Hovering over the "☰" button displays a "Toggle Menu" tooltip.
**♿ Accessibility:** Improves discoverability and reduces cognitive load for sighted mouse and keyboard users by providing immediate contextual text for a non-text symbol.

This falls well under the 50-line limit and relies purely on native HTML tooltips without modifying existing CSS.

---
*PR created automatically by Jules for task [10380296161425724025](https://jules.google.com/task/10380296161425724025) started by @LokiMetaSmith*