### PR TITLE
🎨 Palette: Add helpful empty state for disconnected e-reader

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -37,3 +37,7 @@
 ## 2026-12-11 - [ARIA Titles for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like the hamburger menu) that rely on `aria-label` for screen reader accessibility often lack clear explanations for sighted users on hover, especially keyboard users. This reduces discoverability and can cause confusion about the button's function.
 **Action:** Always complement `aria-label` on icon-only buttons with a matching `title` attribute to provide a helpful tooltip for sighted mouse and keyboard users.
+
+## 2026-12-11 - [Empty State Calls to Action]
+**Learning:** Found an empty state for a disconnected E-Reader that just said "No e-reader connected." This lacked helpful guidance for users, similar to a previous finding where an empty library lacked a call-to-action.
+**Action:** When creating empty states, always reuse the `.empty-state` CSS class for consistency, and provide a helpful call-to-action or instructions (e.g., "Connect your device via USB to view and transfer books.") rather than just stating the lack of data.

--- a/main/web_assets/index.html
+++ b/main/web_assets/index.html
@@ -116,8 +116,8 @@
                         </li>
                     </ul>
                 </div>
-                <div v-else class="no-device">
-                    <p>No e-reader connected.</p>
+                <div v-else class="empty-state">
+                    No e-reader connected.<br><span style="font-size: 0.9em; margin-top: 5px; display: inline-block;">Connect your device via USB to view and transfer books.</span>
                 </div>
             </div>
         </main>


### PR DESCRIPTION
### 💡 What
Updated the empty state message when an E-Reader is disconnected in `index.html`.

### 🎯 Why
The previous empty state was a simple `<p>No e-reader connected.</p>` and did not provide helpful guidance. By changing it to use the `.empty-state` CSS class and adding a clear call-to-action ("Connect your device via USB to view and transfer books."), we guide the user on the next steps to take, preventing them from feeling stuck. This aligns with other empty states in the application, such as the local library empty state.

### 📸 Before/After
**Before:**
A plain, left-aligned paragraph text "No e-reader connected."

**After:**
A styled, italicized text using the `--ink-muted` color palette, featuring the instruction "No e-reader connected." followed by a smaller, block-aligned hint "Connect your device via USB to view and transfer books."

### ♿ Accessibility
The empty state uses the established `.empty-state` styling which utilizes `--ink-muted` designed for WCAG AA compliance against dark backgrounds, preventing contrast issues. The helpful text reduces cognitive load by explaining exactly how to resolve the empty state.

---
*PR created automatically by Jules for task [7622108034670471388](https://jules.google.com/task/7622108034670471388) started by @LokiMetaSmith*