### PR TITLE
🎨 Palette: Fix inline form validation in board.html

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -41,3 +41,7 @@
 ## 2026-12-11 - [Empty State Calls to Action]
 **Learning:** Found an empty state for a disconnected E-Reader that just said "No e-reader connected." This lacked helpful guidance for users, similar to a previous finding where an empty library lacked a call-to-action.
 **Action:** When creating empty states, always reuse the `.empty-state` CSS class for consistency, and provide a helpful call-to-action or instructions (e.g., "Connect your device via USB to view and transfer books.") rather than just stating the lack of data.
+
+## 2026-08-25 - [Inline Form Validation vs Native Tooltips]
+**Learning:** When using custom `aria-live` inline validation messages, retaining standard browser validation (via the `required` attribute) can cause native tooltips to trigger, silently blocking form submission and preventing custom JS logic from firing. The form submission logic previously used a confusing loop between `onsubmit` and `onclick` just to call `checkValidity()`, resulting in a poor experience and broken feedback.
+**Action:** When implementing custom inline form validation, always add the `novalidate` attribute to the `<form>` tag to disable native tooltips, while keeping the semantic `required` attributes on inputs for screen readers. Use a clean `onsubmit="event.preventDefault(); doCustomLogic();"` approach.

--- a/main/web_assets/board.html
+++ b/main/web_assets/board.html
@@ -339,7 +339,7 @@ body {
      text-align:center;padding:10px 16px;font-weight:600">
   📋 This board is currently full. Check back once some posts have expired. 📋
 </div>
-<form class="post-form" onsubmit="event.preventDefault(); document.getElementById('postBtn').click();">
+<form class="post-form" novalidate onsubmit="event.preventDefault(); doPost();">
   <div class="form-row">
 
     <div class="field field-name">
@@ -380,7 +380,7 @@ body {
       <button type="button" class="exp-btn" aria-pressed="false" onclick="setExpiry(72,  this)">3 days</button>
       <button type="button" class="exp-btn active" aria-pressed="true" onclick="setExpiry(168, this)">1 week</button>
     </div>
-    <button type="submit" class="post-btn" id="postBtn" onclick="if(this.form.checkValidity()) doPost();">POST</button>
+    <button type="submit" class="post-btn" id="postBtn">POST</button>
   </div>
 </form>
 


### PR DESCRIPTION
💡 What: Fixed an issue where the inline validation feedback for the community board's "Message" field was not being displayed because native browser tooltips were hijacking the event. Added `novalidate` to the form to disable the visual popups, while preserving the semantic `required` attributes.
🎯 Why: Without `novalidate`, an empty form submission would trigger a browser tooltip and halt JavaScript execution, causing the custom `aria-live` error message intended for screen readers to never display. The form submission logic was also unnecessarily convoluted (submitting triggered a click on a button which manually evaluated validity).
📸 Before/After: Before, submitting an empty form just showed a default browser tooltip (or silently failed) with no `aria-live` update. After, the intended "Message is required to post." text successfully appears inline in red below the input box.
♿ Accessibility: Ensures that screen readers receive the custom, descriptive error message via the `aria-live="polite"` region, while maintaining the `required` / `aria-required` tags on inputs.

---
*PR created automatically by Jules for task [13930914718398266493](https://jules.google.com/task/13930914718398266493) started by @LokiMetaSmith*