### PR TITLE
🎨 Palette: [Prevent silent validation failures on forms]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -45,3 +45,11 @@
 ## 2026-08-25 - [Inline Form Validation vs Native Tooltips]
 **Learning:** When using custom `aria-live` inline validation messages, retaining standard browser validation (via the `required` attribute) can cause native tooltips to trigger, silently blocking form submission and preventing custom JS logic from firing. The form submission logic previously used a confusing loop between `onsubmit` and `onclick` just to call `checkValidity()`, resulting in a poor experience and broken feedback.
 **Action:** When implementing custom inline form validation, always add the `novalidate` attribute to the `<form>` tag to disable native tooltips, while keeping the semantic `required` attributes on inputs for screen readers. Use a clean `onsubmit="event.preventDefault(); doCustomLogic();"` approach.
+
+## 2026-12-11 - [Custom Form Validation Conflicts]
+**Learning:** Implementing custom JavaScript validation () on forms with  inputs can cause browsers to block submission silently due to native HTML5 validation tooltips failing to appear or interfering with the custom logic.
+**Action:** When overriding form submission to use custom inline validation feedback, always add the `novalidate` attribute to the `<form>` element. This disables the native browser tooltips while keeping the semantic `required` attributes for screen readers.
+
+## 2026-12-11 - [Custom Form Validation Conflicts]
+**Learning:** Implementing custom JavaScript validation on forms with required inputs can cause browsers to block submission silently due to native HTML5 validation tooltips failing to appear or interfering with the custom logic.
+**Action:** When overriding form submission to use custom inline validation feedback, always add the `novalidate` attribute to the form element. This disables the native browser tooltips while keeping the semantic required attributes for screen readers.

--- a/main/web_assets/admin.html
+++ b/main/web_assets/admin.html
@@ -205,7 +205,7 @@ textarea.restore-area:focus { border-color: var(--accent-dark); }
 </header>
 
 <!-- Password gate -->
-<form id="gate" onsubmit="event.preventDefault(); tryLogin();">
+<form id="gate" novalidate onsubmit="event.preventDefault(); tryLogin();">
   <h2>Admin Access</h2>
   <label for="keyIn">Admin Access Key <span aria-hidden="true" style="color: #ff8a80;">*</span></label>
   <div style="display: flex; gap: 8px; margin-bottom: 10px;">
@@ -222,7 +222,7 @@ textarea.restore-area:focus { border-color: var(--accent-dark); }
   <div class="section">
     <div class="section-head">Admin Key</div>
     <div class="section-body">
-      <form class="row" onsubmit="event.preventDefault(); doSetKey(this.querySelector('button[type=submit]'));">
+      <form class="row" novalidate onsubmit="event.preventDefault(); doSetKey(this.querySelector('button[type=submit]'));">
         <div class="fld">
           <label for="newKey">New Key (min 4 characters) <span aria-hidden="true" style="color: #ff8a80;">*</span></label>
           <div style="display: flex; gap: 8px;">

--- a/main/web_assets/index.html
+++ b/main/web_assets/index.html
@@ -37,7 +37,7 @@
 
                 <div id="uploadSection" class="upload-section" style="display: none; margin-bottom: 20px; padding: 15px; background-color: rgba(0,0,0,0.2); border-radius: 8px;">
                     <h3 style="margin-top: 0;">Upload Book</h3>
-                    <form id="uploadForm" onsubmit="uploadBook(event)" style="display: flex; flex-wrap: wrap; gap: 10px; align-items: flex-end;">
+                    <form id="uploadForm" novalidate onsubmit="uploadBook(event)" style="display: flex; flex-wrap: wrap; gap: 10px; align-items: flex-end;">
                         <div>
                             <label for="uploadFile" style="display: block; font-size: 0.9em; margin-bottom: 5px;">File <span aria-hidden="true" style="color: #ff8a80;">*</span></label>
                             <input type="file" id="uploadFile" required>

--- a/main/web_assets/script.js
+++ b/main/web_assets/script.js
@@ -331,7 +331,23 @@ async function uploadBook(event) {
     const authorInput = document.getElementById('uploadAuthor');
     const uploadBtn = document.getElementById('uploadBtn');
 
-    if (!fileInput || !fileInput.files.length) return;
+    const errEl = document.getElementById('uploadError');
+
+    if (!fileInput || !fileInput.files.length) {
+        if (errEl) { errEl.style.display = 'block'; errEl.textContent = 'Please select a file to upload.'; }
+        if (fileInput) fileInput.focus();
+        return;
+    }
+    if (titleInput && !titleInput.value.trim()) {
+        if (errEl) { errEl.style.display = 'block'; errEl.textContent = 'Please enter a title.'; }
+        titleInput.focus();
+        return;
+    }
+    if (authorInput && !authorInput.value.trim()) {
+        if (errEl) { errEl.style.display = 'block'; errEl.textContent = 'Please enter an author.'; }
+        authorInput.focus();
+        return;
+    }
 
     const file = fileInput.files[0];
     const title = titleInput ? titleInput.value : 'Unknown Title';
@@ -339,7 +355,6 @@ async function uploadBook(event) {
     const filename = file.name;
 
     state.isUploading = true;
-    const errEl = document.getElementById('uploadError');
     const succEl = document.getElementById('uploadSuccess');
     if (errEl) { errEl.style.display = 'none'; errEl.textContent = ''; }
     if (succEl) { succEl.style.display = 'none'; }

--- a/main/web_assets/setup.html
+++ b/main/web_assets/setup.html
@@ -21,7 +21,7 @@
     <div class="container">
         <h1>Wi-Fi Setup</h1>
         <p>Connect your E-Book Librarian to your local Wi-Fi network.</p>
-        <form action="/save-credentials" method="POST" onsubmit="const btn = this.querySelector('button[type=submit]'); btn.disabled = true; btn.textContent = 'Connecting...'; return true;">
+        <form action="/save-credentials" method="POST" novalidate onsubmit="const ssidIn = document.getElementById('ssid'); if (!ssidIn.value.trim()) { const stat = document.getElementById('status'); stat.textContent = 'Please enter a Wi-Fi Network Name (SSID).'; stat.className = 'status-message error'; ssidIn.focus(); return false; } const btn = this.querySelector('button[type=submit]'); btn.disabled = true; btn.textContent = 'Connecting...'; return true;">
             <div style="margin-bottom: 15px;">
                 <label for="ssid" style="display: block; text-align: left; margin-bottom: 5px; font-weight: bold; color: #555; margin-left: 5%;">Wi-Fi Network Name (SSID) <span aria-hidden="true" style="color: #dc3545;">*</span></label>
                 <input type="text" id="ssid" name="ssid" placeholder="e.g., MyHomeNetwork" required style="margin-bottom: 0;">

--- a/test_setup_ux.py
+++ b/test_setup_ux.py
@@ -24,16 +24,20 @@ def test_setup_page():
 
         # Verify unmasked state
         assert password_input.get_attribute("type") == "text"
-        assert show_btn.text_content() == "Hide"
-        assert show_btn.get_attribute("aria-pressed") == "true"
+
+        hide_btn = page.locator("button[aria-label='Hide password']")
+        assert hide_btn.text_content() == "Hide"
+        assert hide_btn.get_attribute("aria-pressed") == "true"
 
         # Click hide button
-        show_btn.click()
+        hide_btn.click()
 
         # Verify masked state
         assert password_input.get_attribute("type") == "password"
-        assert show_btn.text_content() == "Show"
-        assert show_btn.get_attribute("aria-pressed") == "false"
+
+        show_btn2 = page.locator("button[aria-label='Show password']")
+        assert show_btn2.text_content() == "Show"
+        assert show_btn2.get_attribute("aria-pressed") == "false"
 
         print("Setup page UX verified successfully.")
 


### PR DESCRIPTION
💡 **What**: Added the `novalidate` attribute to several forms (`index.html`, `admin.html`, `setup.html`) and improved their custom JS validation to provide explicit inline error messages and focus management when inputs are invalid.
🎯 **Why**: Previously, if a user missed a required field, the browser would silently block the form submission because native tooltips interfere with the custom JS `onsubmit` logic. This resulted in no feedback and a broken experience. 
📸 **Before/After**: 
- **Before**: Submitting an empty book upload form or Wi-Fi setup form did nothing; the user was stuck without feedback.
- **After**: The forms now display a clear, accessible error message inline (e.g., "Please select a file to upload") and automatically focus the invalid input.
♿ **Accessibility**: 
- Retained the semantic `required` attributes for screen readers while bypassing the problematic native visual tooltips.
- Leveraged existing `aria-live` regions for error messages to ensure screen readers announce validation failures immediately.
- Managed focus programmatically to guide keyboard users directly to the invalid input.

---
*PR created automatically by Jules for task [1711259922942461557](https://jules.google.com/task/1711259922942461557) started by @LokiMetaSmith*