### PR TITLE
🎨 Palette: Fix character hint visibility on form reset

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -53,3 +53,7 @@
 ## 2026-12-11 - [Custom Form Validation Conflicts]
 **Learning:** Implementing custom JavaScript validation on forms with required inputs can cause browsers to block submission silently due to native HTML5 validation tooltips failing to appear or interfering with the custom logic.
 **Action:** When overriding form submission to use custom inline validation feedback, always add the `novalidate` attribute to the form element. This disables the native browser tooltips while keeping the semantic required attributes for screen readers.
+
+## 2026-12-11 - [Visible Character Limits Reset in Forms]
+**Learning:** When resetting forms that include visible character limit hints (e.g., '0/300'), ensure the hint text is explicitly reset to its initial count rather than being cleared entirely, which would incorrectly hide the indicator from the user for their next entry.
+**Action:** Always reset character hint containers explicitly back to their default state (e.g., `'0/300'`) upon form submission, preventing the count from silently disappearing.

--- a/main/web_assets/board.html
+++ b/main/web_assets/board.html
@@ -629,7 +629,8 @@ async function doPost() {
     });
 
     document.getElementById('msgIn').value      = '';
-    document.getElementById('msgHint').textContent = '';
+    document.getElementById('msgHint').textContent = '0/300';
+    document.getElementById('msgHint').className = 'char-hint';
   } finally {
     if (btn) {
       btn.disabled = false;


### PR DESCRIPTION
### 💡 What
This patch fixes an issue on the Community Hub board where, after submitting a post, the character count limit hint (`0/300`) for the new message text area disappeared completely until the user started typing again. It does this by manually resetting the `msgHint`'s text content to `'0/300'` and class to `'char-hint'` during the form reset.

### 🎯 Why
Users rely on explicit indicators like `0/300` to understand constraints prior to entering information. Hiding this information conditionally after their first form interaction creates an inconsistent UX. 

### 📸 Before/After
*(Before)* The hint container was cleared (`textContent = ''`), causing the visual hint to vanish.
*(After)* The hint container now gracefully resets to `0/300`. See screenshot attached for the correct restored default state after a post.

### ♿ Accessibility
The character hint explicitly retains its base class (`char-hint`), which keeps its structural visual styling intact without falsely asserting `.warn` status visually immediately after reset. Additionally, it leverages the existing `aria-live="polite"` region appropriately by cleanly restoring its baseline text for screen readers if they review the region.

---
*PR created automatically by Jules for task [3625016806145217671](https://jules.google.com/task/3625016806145217671) started by @LokiMetaSmith*